### PR TITLE
Markdown content front matter, use createdAt and updatedAt like Nuxt does

### DIFF
--- a/components/blog/BlogListModelByYear.vue
+++ b/components/blog/BlogListModelByYear.vue
@@ -20,7 +20,7 @@
               path: content.path,
               meta: {
                 locale: content.locale ? content.locale : 'en-CA',
-                date: content.date,
+                date: content.createdAt,
               },
             }"
             class="font-serif text-xl italic no-underline"

--- a/components/global/AppContentDate.vue
+++ b/components/global/AppContentDate.vue
@@ -1,5 +1,5 @@
 <template>
-  <time v-if="content.date" :datetime="datetime" :title="textual">
+  <time v-if="content.createdAt" :datetime="datetime" :title="textual">
     {{ yyyymmdd }}
   </time>
 </template>
@@ -35,7 +35,7 @@
     },
     computed: {
       yyyymmdd(): string {
-        const { date } = this.content
+        const date = this.content?.createdAt
         let out = ''
         if (date) {
           const first = date.split('T')[0]
@@ -44,8 +44,8 @@
         return out
       },
       datetime(): string {
-        const { date } = this.content
-        return date
+        const createdAt = this.content?.createdAt
+        return createdAt
       },
       textual(): string {
         return this.formatDate({
@@ -60,7 +60,7 @@
         let out = ''
         try {
           const locale = this.content?.locale ?? 'fr-CA'
-          out = this.content?.date ?? ''
+          out = this.content?.createdAt ?? ''
           const { temporalDate = '' } = getPrettyfiedTemporalDate(
             this.content,
             locale,

--- a/content/about.md
+++ b/content/about.md
@@ -1,8 +1,8 @@
 ---
 title: À propos
 locale: fr-CA
-created: 2009-07-09
-updated: 2023-02-18
+createdAt: 2009-07-09
+updatedAt: 2023-02-18
 canonical: https://renoirboulanger.com/about/
 status: publish
 revising: true

--- a/content/blog/2005/09/first-post.md
+++ b/content/blog/2005/09/first-post.md
@@ -1,8 +1,8 @@
 ---
 title: Premier billet
 locale: fr-CA
-created: 2005-09-16
-updated: 2017-11-10
+createdAt: 2005-09-16
+updatedAt: 2017-11-10
 canonical: 'https://renoirboulanger.com/blog/2005/09/first-post/'
 status: publish
 revising: true

--- a/content/blog/2005/09/journee-blanche-d-inquietudes.md
+++ b/content/blog/2005/09/journee-blanche-d-inquietudes.md
@@ -1,8 +1,8 @@
 ---
 title: Journée blanche d’inquiétudes
 locale: fr-CA
-created: 2005-09-23
-updated: 2023-11-15
+createdAt: 2005-09-23
+updatedAt: 2023-11-15
 canonical: https://renoirboulanger.com/blog/2005/09/journee-blanche-d-inquietudes/
 status: publish
 revising: true

--- a/content/blog/2005/09/redondance.md
+++ b/content/blog/2005/09/redondance.md
@@ -2,8 +2,8 @@
 title: >-
   Redondance des serveurs : stratégie pour améliorer la résilience des sites web
 locale: fr-CA
-created: 2005-09-21
-updated: 2023-11-15
+createdAt: 2005-09-21
+updatedAt: 2023-11-15
 canonical: https://renoirboulanger.com/blog/2005/09/redondance/
 status: publish
 revising: true

--- a/content/blog/2005/12/detection-langue.md
+++ b/content/blog/2005/12/detection-langue.md
@@ -1,8 +1,8 @@
 ---
 title: Detection de langue en PHP
 locale: fr-CA
-created: 2005-12-22
-updated: 2024-08-08
+createdAt: 2005-12-22
+updatedAt: 2024-08-08
 canonical: https://renoirboulanger.com/blog/2005/12/detection-langue/
 status: publish
 revising: false

--- a/content/blog/2006/06/une-erreur-de-manipulation-qui-a-coute.md
+++ b/content/blog/2006/06/une-erreur-de-manipulation-qui-a-coute.md
@@ -1,8 +1,8 @@
 ---
 title: Une erreur de manipulation qui a coûté
 locale: fr-CA
-created: 2006-06-10
-updated: 2023-11-15
+createdAt: 2006-06-10
+updatedAt: 2023-11-15
 canonical: >-
   https://renoirboulanger.com/blog/2006/06/une-erreur-de-manipulation-qui-a-coute/
 status: publish

--- a/content/blog/2006/07/transactions-carte-credit.md
+++ b/content/blog/2006/07/transactions-carte-credit.md
@@ -1,8 +1,8 @@
 ---
 title: Transactions carte credit
 locale: fr-CA
-created: 2006-07-14
-updated: 2009-08-14
+createdAt: 2006-07-14
+updatedAt: 2009-08-14
 canonical: https://renoirboulanger.com/blog/2006/07/transactions-carte-credit/
 status: publish
 revising: true

--- a/content/blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical.md
+++ b/content/blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical.md
@@ -1,8 +1,8 @@
 ---
 title: Installer VMWare sur Ubuntu server avec le repositoire de Canonical
 locale: fr-CA
-created: 2006-12-21
-updated: 2006-12-25
+createdAt: 2006-12-21
+updatedAt: 2006-12-25
 canonical: 'https://renoirboulanger.com/blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical/'
 status: publish
 revising: false

--- a/content/blog/2007/01/le-futur-du-pc.md
+++ b/content/blog/2007/01/le-futur-du-pc.md
@@ -1,8 +1,8 @@
 ---
 title: Le futur du PC
 locale: fr-CA
-created: 2007-01-25
-updated: 2009-08-27
+createdAt: 2007-01-25
+updatedAt: 2009-08-27
 canonical: https://renoirboulanger.com/blog/2007/01/le-futur-du-pc/
 status: publish
 revising: true

--- a/content/blog/2007/02/conversion-et-resampling-image.md
+++ b/content/blog/2007/02/conversion-et-resampling-image.md
@@ -1,8 +1,8 @@
 ---
 title: Conversion et resampling image
 locale: fr-CA
-created: 2007-02-21
-updated: 2013-03-27
+createdAt: 2007-02-21
+updatedAt: 2013-03-27
 canonical: https://renoirboulanger.com/blog/2007/02/conversion-et-resampling-image/
 status: publish
 revising: true

--- a/content/blog/2007/02/une-machine-virtuelle-gentoo.md
+++ b/content/blog/2007/02/une-machine-virtuelle-gentoo.md
@@ -1,8 +1,8 @@
 ---
 title: Une machine virtuelle Gentoo
 locale: fr-CA
-created: 2007-02-10
-updated: 2013-03-27
+createdAt: 2007-02-10
+updatedAt: 2013-03-27
 canonical: https://renoirboulanger.com/blog/2007/02/une-machine-virtuelle-gentoo/
 status: publish
 revising: true

--- a/content/blog/2007/04/installation-rhel4-sur-un-dell-poweredge-860.md
+++ b/content/blog/2007/04/installation-rhel4-sur-un-dell-poweredge-860.md
@@ -6,8 +6,8 @@ canonical: >-
 status: publish
 revising: true
 migrateCode: true
-created: '2007-04-16'
-updated: '2013-03-27'
+createdAt: '2007-04-16'
+updatedAt: '2013-03-27'
 tags:
   - linux
   - tutoriels

--- a/content/blog/2007/04/login-ssh-sans-mot-de-passe.md
+++ b/content/blog/2007/04/login-ssh-sans-mot-de-passe.md
@@ -5,8 +5,8 @@ canonical: https://renoirboulanger.com/blog/2007/04/login-ssh-sans-mot-de-passe/
 status: publish
 revising: true
 migrateCode: true
-created: '2007-04-10'
-updated: '2013-03-27'
+createdAt: '2007-04-10'
+updatedAt: '2013-03-27'
 tags:
   - linux
   - tutoriels

--- a/content/blog/2007/04/periode-de-tests.md
+++ b/content/blog/2007/04/periode-de-tests.md
@@ -8,8 +8,8 @@ migrateLinks: false
 migrateImages: false
 gallery: false
 caption: false
-created: '2007-04-25'
-updated: '2013-03-27'
+createdAt: '2007-04-25'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2007/05/critique-de-roman-deception-point.md
+++ b/content/blog/2007/05/critique-de-roman-deception-point.md
@@ -4,8 +4,8 @@ title: Critique de Roman Deception point
 canonical: https://renoirboulanger.com/blog/2007/05/critique-de-roman-deception-point/
 status: publish
 revising: true
-created: '2007-05-28'
-updated: '2013-03-27'
+createdAt: '2007-05-28'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2007/05/critique-de-roman-forteresse-digitale.md
+++ b/content/blog/2007/05/critique-de-roman-forteresse-digitale.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2007/05/critique-de-roman-forteresse-digitale/
 status: publish
 revising: true
-created: '2007-05-12'
-updated: '2013-03-27'
+createdAt: '2007-05-12'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2007/05/invitalisation.md
+++ b/content/blog/2007/05/invitalisation.md
@@ -4,8 +4,8 @@ title: Invitalisation
 canonical: https://renoirboulanger.com/blog/2007/05/invitalisation/
 status: publish
 revising: true
-created: '2007-05-19'
-updated: '2013-03-27'
+createdAt: '2007-05-19'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2007/05/montage-de-dossiers-distants-via-sshfs.md
+++ b/content/blog/2007/05/montage-de-dossiers-distants-via-sshfs.md
@@ -1,8 +1,8 @@
 ---
 title: Montage de dossiers distants via SSHFS
 locale: fr-CA
-created: 2007-05-31
-updated: 2013-03-27
+createdAt: 2007-05-31
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2007/05/montage-de-dossiers-distants-via-sshfs/
 status: publish

--- a/content/blog/2007/06/critique-de-roman-le-davinci-code.md
+++ b/content/blog/2007/06/critique-de-roman-le-davinci-code.md
@@ -5,8 +5,8 @@ canonical: https://renoirboulanger.com/blog/2007/06/critique-de-roman-le-davinci
 status: publish
 revising: true
 caracteresBizzares: true
-created: '2007-06-13'
-updated: '2013-03-27'
+createdAt: '2007-06-13'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2007/06/doubler-la-fiabilite-avec-un-miroir-mysql-un-mini-howto.md
+++ b/content/blog/2007/06/doubler-la-fiabilite-avec-un-miroir-mysql-un-mini-howto.md
@@ -11,8 +11,8 @@ gallery: false
 migrateCode: true
 migrateImages: false
 migrateLinks: true
-created: '2007-06-14'
-updated: '2013-03-27'
+createdAt: 2007-06-14
+updatedAt: 2013-03-27
 tags:
   - linux
   - tutoriels

--- a/content/blog/2007/06/internet-explorer-6-un-upgrade-obligatoire-svp.md
+++ b/content/blog/2007/06/internet-explorer-6-un-upgrade-obligatoire-svp.md
@@ -1,8 +1,8 @@
 ---
 title: 'Microsoft Internet Explorer 6, une mise-à-jour obligatoire, SVP.'
 locale: fr-CA
-created: 2007-06-12
-updated: 2013-03-27
+createdAt: 2007-06-12
+updatedAt: 2013-03-27
 canonical: https://renoirboulanger.com/blog/2007/06/internet-explorer-6-un-upgrade-obligatoire-svp/
 status: publish
 revising: true

--- a/content/blog/2007/06/une-boite-qui-traine.md
+++ b/content/blog/2007/06/une-boite-qui-traine.md
@@ -1,8 +1,8 @@
 ---
 title: Une boîte qui traîne
 locale: fr-CA
-created: 2007-06-26
-updated: 2013-03-27
+createdAt: 2007-06-26
+updatedAt: 2013-03-27
 canonical: https://renoirboulanger.com/blog/2007/06/une-boite-qui-traine/
 status: publish
 revising: true

--- a/content/blog/2007/08/farenheit-911-et-mes-impressions.md
+++ b/content/blog/2007/08/farenheit-911-et-mes-impressions.md
@@ -4,8 +4,8 @@ title: Le film Farenheit 9/11 de Michael More et mes impressions
 canonical: https://renoirboulanger.com/blog/2007/08/farenheit-911-et-mes-impressions/
 status: publish
 revising: true
-created: '2007-08-21'
-updated: '2013-03-27'
+createdAt: '2007-08-21'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2007/08/un-equivalent-open-du-iphone.md
+++ b/content/blog/2007/08/un-equivalent-open-du-iphone.md
@@ -5,8 +5,8 @@ canonical: https://renoirboulanger.com/blog/2007/08/un-equivalent-open-du-iphone
 status: publish
 revising: true
 caracteresBizzares: true
-created: '2007-08-14'
-updated: '2013-03-27'
+createdAt: '2007-08-14'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2007/09/apple-remet-du-sien-avec-son-ipod-touch.md
+++ b/content/blog/2007/09/apple-remet-du-sien-avec-son-ipod-touch.md
@@ -6,8 +6,8 @@ canonical: >-
 status: publish
 revising: true
 images: true
-created: '2007-09-06'
-updated: '2013-03-27'
+createdAt: '2007-09-06'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 coverImage:

--- a/content/blog/2007/09/copier-un-fichier-dun-serveur-a-lautre-en-le-compressant-pour-la-route.md
+++ b/content/blog/2007/09/copier-un-fichier-dun-serveur-a-lautre-en-le-compressant-pour-la-route.md
@@ -8,8 +8,8 @@ canonical: >-
 status: publish
 revising: true
 migrateCode: true
-created: '2007-09-25'
-updated: '2013-03-27'
+createdAt: '2007-09-25'
+updatedAt: '2013-03-27'
 tags:
   - linux
   - outils

--- a/content/blog/2007/09/lorsque-gerer-un-reseau-peut-rimer-avec-vigilance-plutot-que-reparation.md
+++ b/content/blog/2007/09/lorsque-gerer-un-reseau-peut-rimer-avec-vigilance-plutot-que-reparation.md
@@ -6,8 +6,8 @@ canonical: >-
 status: publish
 revising: true
 caracteresBizzares: true
-created: '2007-09-28'
-updated: '2013-03-27'
+createdAt: '2007-09-28'
+updatedAt: '2013-03-27'
 tags:
   - linux
   - outils

--- a/content/blog/2007/09/quelques-blogs-que-je-lis-frequemment.md
+++ b/content/blog/2007/09/quelques-blogs-que-je-lis-frequemment.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2007/09/quelques-blogs-que-je-lis-frequemment/
 status: publish
 revising: true
-created: '2007-09-18'
-updated: '2013-03-27'
+createdAt: '2007-09-18'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2007/09/revue-de-dont-make-me-think.md
+++ b/content/blog/2007/09/revue-de-dont-make-me-think.md
@@ -5,8 +5,8 @@ canonical: https://renoirboulanger.com/blog/2007/09/revue-de-dont-make-me-think/
 status: publish
 revising: true
 images: true
-created: '2007-09-07'
-updated: '2013-03-27'
+createdAt: '2007-09-07'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2007/10/fait-dusabilite-no2-nous-ne-faisons-pas-de-choix-optimaux-nous-choisisons-le-premier-choix-coherent.md
+++ b/content/blog/2007/10/fait-dusabilite-no2-nous-ne-faisons-pas-de-choix-optimaux-nous-choisisons-le-premier-choix-coherent.md
@@ -8,8 +8,8 @@ canonical: >-
 status: publish
 revising: true
 images: true
-created: '2007-10-12'
-updated: '2013-03-27'
+createdAt: '2007-10-12'
+updatedAt: '2013-03-27'
 tags:
   - integration
   - usability

--- a/content/blog/2007/10/ideologie-inboxzero.md
+++ b/content/blog/2007/10/ideologie-inboxzero.md
@@ -5,8 +5,8 @@ canonical: https://renoirboulanger.com/blog/2007/10/ideologie-inboxzero/
 status: publish
 revising: true
 caracteresBizzares: true
-created: '2007-10-15'
-updated: '2013-03-27'
+createdAt: '2007-10-15'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2007/10/tunnel-ssh-avec-session-distante-en-console-vmware.md
+++ b/content/blog/2007/10/tunnel-ssh-avec-session-distante-en-console-vmware.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2007/10/tunnel-ssh-avec-session-distante-en-console-vmware/
 status: publish
 revising: true
-created: '2007-10-03'
-updated: '2013-03-27'
+createdAt: '2007-10-03'
+updatedAt: '2013-03-27'
 tags:
   - linux
   - securite

--- a/content/blog/2007/11/ajouter-de-la-valeur-a-un-mot-de-passe-des-astuces.md
+++ b/content/blog/2007/11/ajouter-de-la-valeur-a-un-mot-de-passe-des-astuces.md
@@ -6,8 +6,8 @@ canonical: >-
 status: publish
 revising: true
 caracteresBizzares: true
-created: '2007-11-20'
-updated: '2013-03-27'
+createdAt: '2007-11-20'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2007/11/fait-dusabilite-no3-nous-nessayons-pas-de-comprendre-les-choses-nous-fouillons.md
+++ b/content/blog/2007/11/fait-dusabilite-no3-nous-nessayons-pas-de-comprendre-les-choses-nous-fouillons.md
@@ -8,8 +8,8 @@ canonical: >-
 status: publish
 revising: true
 images: true
-created: '2007-11-23'
-updated: '2013-03-27'
+createdAt: '2007-11-23'
+updatedAt: '2013-03-27'
 tags:
   - integration
   - techniques

--- a/content/blog/2007/11/mon-espace-de-travail.md
+++ b/content/blog/2007/11/mon-espace-de-travail.md
@@ -9,8 +9,8 @@ gallery: false
 migrateCode: true
 migrateImages: true
 migrateLinks: false
-created: '2007-11-26'
-updated: '2013-03-27'
+createdAt: '2007-11-26'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2007/11/un-portail-quebecois-qui-a-eu-une-mention-speciale-utilisabilite-quebec.md
+++ b/content/blog/2007/11/un-portail-quebecois-qui-a-eu-une-mention-speciale-utilisabilite-quebec.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2007/11/un-portail-quebecois-qui-a-eu-une-mention-speciale-utilisabilite-quebec/
 status: publish
 revising: true
-created: '2007-11-07'
-updated: '2013-03-27'
+createdAt: '2007-11-07'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2007/11/walmart-vend-des-ordinateurs-a-200-sous-ubuntu-linux.md
+++ b/content/blog/2007/11/walmart-vend-des-ordinateurs-a-200-sous-ubuntu-linux.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2007/11/walmart-vend-des-ordinateurs-a-200-sous-ubuntu-linux/
 status: publish
 revising: true
-created: '2007-11-09'
-updated: '2013-03-27'
+createdAt: '2007-11-09'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2008/04/effacer-un-disque-dur.md
+++ b/content/blog/2008/04/effacer-un-disque-dur.md
@@ -1,8 +1,8 @@
 ---
 title: Effacer complètement un disque dur de façon sécuritaire
 locale: fr-CA
-created: 2008-04-16
-updated: 2013-03-27
+createdAt: 2008-04-16
+updatedAt: 2013-03-27
 canonical: https://renoirboulanger.com/blog/2008/04/effacer-un-disque-dur/
 status: publish
 revising: true

--- a/content/blog/2008/04/jeudi-24-avril-2008-party-de-lancement-de-hardy-heron-an-ubuntu-linux-party-au-saint-sulpice.md
+++ b/content/blog/2008/04/jeudi-24-avril-2008-party-de-lancement-de-hardy-heron-an-ubuntu-linux-party-au-saint-sulpice.md
@@ -3,8 +3,8 @@ title: >-
   Jeudi 24 avril 2008 Party de lancement de Hardy Heron an Ubuntu Linux Party au
   Saint-Sulpice
 locale: fr-CA
-created: 2008-04-14
-updated: 2013-03-27
+createdAt: 2008-04-14
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2008/04/jeudi-24-avril-2008-party-de-lancement-de-hardy-heron-an-ubuntu-linux-party-au-saint-sulpice/
 status: publish

--- a/content/blog/2008/04/la-publicite-du-monde-celibataire-sur-facebook-et-les-fausses-representations.md
+++ b/content/blog/2008/04/la-publicite-du-monde-celibataire-sur-facebook-et-les-fausses-representations.md
@@ -1,8 +1,8 @@
 ---
 title: La publicite du monde celibataire sur Facebook et les fausses representations
 locale: fr-CA
-created: 2008-04-30
-updated: 2013-06-07
+createdAt: 2008-04-30
+updatedAt: 2013-06-07
 canonical: >-
   https://renoirboulanger.com/blog/2008/04/la-publicite-du-monde-celibataire-sur-facebook-et-les-fausses-representations/
 status: publish

--- a/content/blog/2008/04/pourquoi-le-blogue-bouge-pas.md
+++ b/content/blog/2008/04/pourquoi-le-blogue-bouge-pas.md
@@ -1,8 +1,8 @@
 ---
 title: Pourquoi le blogue bouge pas?
 locale: fr-CA
-created: 2008-04-11
-updated: 2013-03-27
+createdAt: 2008-04-11
+updatedAt: 2013-03-27
 canonical: https://renoirboulanger.com/blog/2008/04/pourquoi-le-blogue-bouge-pas/
 status: publish
 revising: true

--- a/content/blog/2008/04/tester-le-fonctionnement-dun-serveur-smtp.md
+++ b/content/blog/2008/04/tester-le-fonctionnement-dun-serveur-smtp.md
@@ -1,8 +1,8 @@
 ---
 title: Tester le fonctionnement d'un serveur SMTP
 locale: fr-CA
-created: 2008-04-19
-updated: 2014-02-19
+createdAt: 2008-04-19
+updatedAt: 2014-02-19
 canonical: >-
   https://renoirboulanger.com/blog/2008/04/tester-le-fonctionnement-dun-serveur-smtp/
 status: publish

--- a/content/blog/2008/12/les-navigateurs-web-programmes-de-courriels-vous-avez-le-choix.md
+++ b/content/blog/2008/12/les-navigateurs-web-programmes-de-courriels-vous-avez-le-choix.md
@@ -1,8 +1,8 @@
 ---
 title: Les navigateurs web, programmes de courriels, vous avez le choix!
 locale: fr-CA
-created: 2008-12-05
-updated: 2013-06-06
+createdAt: 2008-12-05
+updatedAt: 2013-06-06
 canonical: >-
   https://renoirboulanger.com/blog/2008/12/les-navigateurs-web-programmes-de-courriels-vous-avez-le-choix/
 status: publish

--- a/content/blog/2008/12/quelques-indices-pour-savoir-si-un-message-courriel-est-une-chaine-de-lettre.md
+++ b/content/blog/2008/12/quelques-indices-pour-savoir-si-un-message-courriel-est-une-chaine-de-lettre.md
@@ -1,8 +1,8 @@
 ---
 title: Quelques indices pour savoir si un message courriel est une chaîne de lettre
 locale: fr-CA
-created: 2008-12-04
-updated: 2013-06-07
+createdAt: 2008-12-04
+updatedAt: 2013-06-07
 canonical: >-
   https://renoirboulanger.com/blog/2008/12/quelques-indices-pour-savoir-si-un-message-courriel-est-une-chaine-de-lettre/
 status: publish

--- a/content/blog/2008/12/sensibilisation-sur-les-courriels-non-sollicites.md
+++ b/content/blog/2008/12/sensibilisation-sur-les-courriels-non-sollicites.md
@@ -1,8 +1,8 @@
 ---
 title: Sensibilisation sur les courriels non sollicités
 locale: fr-CA
-created: 2008-12-03
-updated: 2013-06-07
+createdAt: 2008-12-03
+updatedAt: 2013-06-07
 canonical: >-
   https://renoirboulanger.com/blog/2008/12/sensibilisation-sur-les-courriels-non-sollicites/
 status: publish

--- a/content/blog/2009/07/une-petite-lecture-sur-les-attrapes-nigaud-sur-le-web.md
+++ b/content/blog/2009/07/une-petite-lecture-sur-les-attrapes-nigaud-sur-le-web.md
@@ -1,8 +1,8 @@
 ---
 title: Une petite lecture sur les attaques d’hameçonnage et sur la fraude sur le Web
 locale: fr-CA
-created: 2009-07-02
-updated: 2013-06-07
+createdAt: 2009-07-02
+updatedAt: 2013-06-07
 canonical: >-
   https://renoirboulanger.com/blog/2009/07/une-petite-lecture-sur-les-attrapes-nigaud-sur-le-web/
 status: publish

--- a/content/blog/2009/08/a-la-recherche-dun-nouveau-defi.md
+++ b/content/blog/2009/08/a-la-recherche-dun-nouveau-defi.md
@@ -5,8 +5,8 @@ canonical: https://renoirboulanger.com/blog/2009/08/a-la-recherche-dun-nouveau-d
 status: publish
 revising: true
 caracteresBizzares: true
-created: '2009-08-05'
-updated: '2013-03-27'
+createdAt: '2009-08-05'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2009/08/a-vendre-mon-ipod-touch-16go-avec-son-kit-pour-me-procurer-un-iphone.md
+++ b/content/blog/2009/08/a-vendre-mon-ipod-touch-16go-avec-son-kit-pour-me-procurer-un-iphone.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2009/08/a-vendre-mon-ipod-touch-16go-avec-son-kit-pour-me-procurer-un-iphone/
 status: publish
 revising: true
-created: 2009-08-26
-updated: 2015-05-01
+createdAt: 2009-08-26
+updatedAt: 2015-05-01
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2009/08/accessibilite-et-les-liens-externes.md
+++ b/content/blog/2009/08/accessibilite-et-les-liens-externes.md
@@ -10,8 +10,8 @@ gallery: false
 migrateImages: true
 migrateLinks: true
 migrateCode: true
-created: '2009-08-20'
-updated: '2013-03-27'
+createdAt: '2009-08-20'
+updatedAt: '2013-03-27'
 tags:
   - accessibility
   - html

--- a/content/blog/2009/08/conference-de-garr-reynolds-atgoogletalks-sur-comment-presenter-ses-idees.md
+++ b/content/blog/2009/08/conference-de-garr-reynolds-atgoogletalks-sur-comment-presenter-ses-idees.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2009/08/conference-de-garr-reynolds-atgoogletalks-sur-comment-presenter-ses-idees/
 status: publish
 revising: true
-created: '2009-08-18'
-updated: '2013-03-29'
+createdAt: '2009-08-18'
+updatedAt: '2013-03-29'
 tags:
   - inspiration
   - talk

--- a/content/blog/2009/08/faire-son-inventaire-personnel-avec-namminik-com.md
+++ b/content/blog/2009/08/faire-son-inventaire-personnel-avec-namminik-com.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2009/08/faire-son-inventaire-personnel-avec-namminik-com/
 status: publish
 revising: true
-created: '2009-08-14'
-updated: '2013-03-27'
+createdAt: '2009-08-14'
+updatedAt: '2013-03-27'
 tags:
   - outils
   - securite

--- a/content/blog/2009/08/geeknight-ce-soir.md
+++ b/content/blog/2009/08/geeknight-ce-soir.md
@@ -5,8 +5,8 @@ canonical: https://renoirboulanger.com/blog/2009/08/geeknight-ce-soir/
 status: publish
 revising: true
 caption: true
-created: '2009-08-19'
-updated: '2013-03-27'
+createdAt: '2009-08-19'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2009/08/la-cigale-et-la-fourmi-version-quebecoise.md
+++ b/content/blog/2009/08/la-cigale-et-la-fourmi-version-quebecoise.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2009/08/la-cigale-et-la-fourmi-version-quebecoise/
 status: publish
 revising: true
-created: '2009-08-14'
-updated: '2013-03-27'
+createdAt: '2009-08-14'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: >-

--- a/content/blog/2009/08/le-cloud-computing-vulgarise.md
+++ b/content/blog/2009/08/le-cloud-computing-vulgarise.md
@@ -4,8 +4,8 @@ title: Le "Cloud computing" vulgarisé
 canonical: https://renoirboulanger.com/blog/2009/08/le-cloud-computing-vulgarise/
 status: publish
 revising: true
-created: '2009-08-17'
-updated: '2013-03-27'
+createdAt: '2009-08-17'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: >-

--- a/content/blog/2009/08/le-fondateur-de-netscape-est-en-train-de-developper-un-navigateur-web-nouveau-genre.md
+++ b/content/blog/2009/08/le-fondateur-de-netscape-est-en-train-de-developper-un-navigateur-web-nouveau-genre.md
@@ -8,8 +8,8 @@ canonical: >-
 status: publish
 revising: true
 images: true
-created: '2009-08-14'
-updated: '2013-03-27'
+createdAt: '2009-08-14'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: >-

--- a/content/blog/2009/08/manipulation-des-liens-exterieurs-et-les-popup-pour-ameliorer-laccessibilite.md
+++ b/content/blog/2009/08/manipulation-des-liens-exterieurs-et-les-popup-pour-ameliorer-laccessibilite.md
@@ -6,8 +6,8 @@ canonical: >-
 status: publish
 revising: true
 migrateCode: true
-created: '2009-08-23'
-updated: '2013-03-27'
+createdAt: '2009-08-23'
+updatedAt: '2013-03-27'
 categories:
   - programmation
 tags:

--- a/content/blog/2009/08/namminik-dans-le-journal-de-montreal.md
+++ b/content/blog/2009/08/namminik-dans-le-journal-de-montreal.md
@@ -4,8 +4,8 @@ title: Namminik dans le Journal de Montréal
 canonical: https://renoirboulanger.com/blog/2009/08/namminik-dans-le-journal-de-montreal/
 status: publish
 revising: true
-created: '2009-08-14'
-updated: '2013-03-27'
+createdAt: '2009-08-14'
+updatedAt: '2013-03-27'
 tags:
   - outils
 categories:

--- a/content/blog/2009/08/nouvelle-technologie-de-la-realite-augumentee-les-habitants-des-pays-bas-seront-des-premiers.md
+++ b/content/blog/2009/08/nouvelle-technologie-de-la-realite-augumentee-les-habitants-des-pays-bas-seront-des-premiers.md
@@ -3,8 +3,8 @@ title:
   Nouvelle technologie de la Réalité Augumentée, Les habitants des Pays Bas
   seront des premiers
 locale: fr-CA
-created: 2009-08-26
-updated: 2009-08-26
+createdAt: 2009-08-26
+updatedAt: 2009-08-26
 canonical: 'https://renoirboulanger.com/blog/2009/08/nouvelle-technologie-de-la-realite-augumentee-les-habitants-des-pays-bas-seront-des-premiers/'
 status: publish
 revising: true

--- a/content/blog/2009/08/processus-pour-regler-un-probleme-avec-un-ordinateur.md
+++ b/content/blog/2009/08/processus-pour-regler-un-probleme-avec-un-ordinateur.md
@@ -6,8 +6,8 @@ canonical: >-
 status: publish
 revising: true
 images: true
-created: '2009-08-30'
-updated: '2013-03-27'
+createdAt: '2009-08-30'
+updatedAt: '2013-03-27'
 tags:
   - humour
 categories:

--- a/content/blog/2009/08/realisation-site-web-inexis-solution-web-2004.md
+++ b/content/blog/2009/08/realisation-site-web-inexis-solution-web-2004.md
@@ -6,8 +6,8 @@ status: publish
 revising: true
 images: true
 migrateImages: true
-created: '2009-08-20'
-updated: '2013-03-27'
+createdAt: '2009-08-20'
+updatedAt: '2013-03-27'
 categories:
   - portfolio
 tags:

--- a/content/blog/2009/08/realisationgestionnaire-de-service-a-la-clientele-pour-cable-axion.md
+++ b/content/blog/2009/08/realisationgestionnaire-de-service-a-la-clientele-pour-cable-axion.md
@@ -7,8 +7,8 @@ status: publish
 revising: true
 images: true
 migrateImages: true
-created: '2009-08-20'
-updated: '2013-03-27'
+createdAt: '2009-08-20'
+updatedAt: '2013-03-27'
 categories:
   - portfolio
 tags:

--- a/content/blog/2009/08/reduire-son-empreinte-ecologique-et-aussi-thebigask.md
+++ b/content/blog/2009/08/reduire-son-empreinte-ecologique-et-aussi-thebigask.md
@@ -6,8 +6,8 @@ canonical: >-
 status: publish
 revising: true
 migrateLinks: true
-created: '2009-08-28'
-updated: '2013-03-27'
+createdAt: '2009-08-28'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2009/08/si-la-terre-etait-un-village-de-100-personnes.md
+++ b/content/blog/2009/08/si-la-terre-etait-un-village-de-100-personnes.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2009/08/si-la-terre-etait-un-village-de-100-personnes/
 status: publish
 revising: true
-created: '2009-08-17'
-updated: '2013-03-27'
+createdAt: '2009-08-17'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: >-

--- a/content/blog/2009/08/un-firewall-simple-sous-linux-avec-ferm.md
+++ b/content/blog/2009/08/un-firewall-simple-sous-linux-avec-ferm.md
@@ -7,8 +7,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2009-08-19'
-updated: '2013-03-27'
+createdAt: '2009-08-19'
+updatedAt: '2013-03-27'
 tags:
   - linux
   - securite

--- a/content/blog/2009/09/devenir-zend-certified-engineer-avec-php5.md
+++ b/content/blog/2009/09/devenir-zend-certified-engineer-avec-php5.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2009/09/devenir-zend-certified-engineer-avec-php5/
 status: publish
 revising: true
-created: '2009-09-29'
-updated: '2013-03-27'
+createdAt: '2009-09-29'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2009/09/je-prefere-le-pingouin-design-cool-de-tee-shirt.md
+++ b/content/blog/2009/09/je-prefere-le-pingouin-design-cool-de-tee-shirt.md
@@ -6,8 +6,8 @@ canonical: >-
 status: publish
 revising: true
 accentsBizzares: true
-created: '2009-09-14'
-updated: '2013-03-27'
+createdAt: '2009-09-14'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2009/09/pourquoi-tout-ces-caracteres-bizzares.md
+++ b/content/blog/2009/09/pourquoi-tout-ces-caracteres-bizzares.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2009/09/pourquoi-tout-ces-caracteres-bizzares/
 status: publish
 revising: true
-created: '2009-09-19'
-updated: '2013-03-27'
+createdAt: '2009-09-19'
+updatedAt: '2013-03-27'
 tags:
   - html
   - vulgarisation

--- a/content/blog/2009/09/une-vm-linux-qui-sert-au-developpement-php-5-3-avec-eclipse-partie-i.md
+++ b/content/blog/2009/09/une-vm-linux-qui-sert-au-developpement-php-5-3-avec-eclipse-partie-i.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2009/09/une-vm-linux-qui-sert-au-developpement-php-5-3-avec-eclipse-partie-i/
 status: publish
 revising: true
-created: '2009-09-03'
-updated: '2013-03-27'
+createdAt: '2009-09-03'
+updatedAt: '2013-03-27'
 tags:
   - linux
   - tutoriels

--- a/content/blog/2009/09/une-vm-linux-qui-sert-au-developpement-php-5-3-avec-eclipse-partie-ii.md
+++ b/content/blog/2009/09/une-vm-linux-qui-sert-au-developpement-php-5-3-avec-eclipse-partie-ii.md
@@ -7,8 +7,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2009-09-03'
-updated: '2013-03-27'
+createdAt: '2009-09-03'
+updatedAt: '2013-03-27'
 tags:
   - linux
   - logiciel-libre

--- a/content/blog/2009/09/une-vm-linux-qui-sert-au-developpement-php-5-3-avec-eclipse-partie-iii.md
+++ b/content/blog/2009/09/une-vm-linux-qui-sert-au-developpement-php-5-3-avec-eclipse-partie-iii.md
@@ -7,8 +7,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2009-09-09'
-updated: '2013-03-29'
+createdAt: '2009-09-09'
+updatedAt: '2013-03-29'
 tags:
   - linux
   - logiciel-libre

--- a/content/blog/2009/10/pensees-ecrites-a-voix-haute-pour-mon-orientation-professionnelle.md
+++ b/content/blog/2009/10/pensees-ecrites-a-voix-haute-pour-mon-orientation-professionnelle.md
@@ -1,8 +1,8 @@
 ---
 title: Pensées concernant mon orientation professionnelle
 locale: fr-CA
-created: 2009-10-19
-updated: 2013-03-27
+createdAt: 2009-10-19
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2009/10/pensees-ecrites-a-voix-haute-pour-mon-orientation-professionnelle/
 status: publish

--- a/content/blog/2009/10/realisation-du-site-ecurie-royale.md
+++ b/content/blog/2009/10/realisation-du-site-ecurie-royale.md
@@ -1,8 +1,8 @@
 ---
 title: Réalisation du site Écurie Royale [2004]
 locale: fr-CA
-created: 2009-10-28
-updated: 2013-03-27
+createdAt: 2009-10-28
+updatedAt: 2013-03-27
 canonical: https://renoirboulanger.com/blog/2009/10/realisation-du-site-ecurie-royale/
 status: publish
 revising: false

--- a/content/blog/2009/10/realisation-site-de-cable-axion.md
+++ b/content/blog/2009/10/realisation-site-de-cable-axion.md
@@ -6,8 +6,8 @@ status: publish
 revising: true
 caption: true
 migrateImages: true
-created: '2009-10-30'
-updated: '2013-03-27'
+createdAt: '2009-10-30'
+updatedAt: '2013-03-27'
 tags:
   - css
   - geraniumcms

--- a/content/blog/2009/10/rendre-un-mot-de-passe-plus-difficile-a-briser.md
+++ b/content/blog/2009/10/rendre-un-mot-de-passe-plus-difficile-a-briser.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2009/10/rendre-un-mot-de-passe-plus-difficile-a-briser/
 status: publish
 revising: true
-created: '2009-10-18'
-updated: '2013-03-27'
+createdAt: '2009-10-18'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2009/11/google-lance-un-nouveau-protocole-pour-remplacer-http-hello-spdy.md
+++ b/content/blog/2009/11/google-lance-un-nouveau-protocole-pour-remplacer-http-hello-spdy.md
@@ -6,8 +6,8 @@ canonical: >-
 status: publish
 revising: true
 migrateLinks: true
-created: '2009-11-12'
-updated: '2023-11-20'
+createdAt: '2009-11-12'
+updatedAt: '2023-11-20'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2009/11/realisation-de-linterface-logiciel-beebox-2007.md
+++ b/content/blog/2009/11/realisation-de-linterface-logiciel-beebox-2007.md
@@ -8,8 +8,8 @@ revising: true
 caption: true
 migrateImages: true
 migrateLinks: true
-created: '2009-11-10'
-updated: '2013-03-27'
+createdAt: '2009-11-10'
+updatedAt: '2013-03-27'
 tags:
   - css
   - html

--- a/content/blog/2009/11/realisation-du-site-de-remises-real-lamontagne-2004.md
+++ b/content/blog/2009/11/realisation-du-site-de-remises-real-lamontagne-2004.md
@@ -7,8 +7,8 @@ status: publish
 revising: true
 caption: true
 migrateImages: true
-created: '2009-11-05'
-updated: '2013-03-27'
+createdAt: '2009-11-05'
+updatedAt: '2013-03-27'
 tags:
   - html
   - inexis

--- a/content/blog/2009/11/realisation-du-site-et-de-image-produit-de-beebox.md
+++ b/content/blog/2009/11/realisation-du-site-et-de-image-produit-de-beebox.md
@@ -1,8 +1,8 @@
 ---
 title: Réalisation du site et de l’Image «branding» de Beebox [2008]
 locale: fr-CA
-created: 2009-11-28
-updated: 2013-03-27
+createdAt: 2009-11-28
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2009/11/realisation-du-site-et-de-limage-«branding»-de-beebox-2008/
 status: publish

--- a/content/blog/2009/11/realisation-du-site-muse-des-beaux-arts-de-sherbrooke-2005.md
+++ b/content/blog/2009/11/realisation-du-site-muse-des-beaux-arts-de-sherbrooke-2005.md
@@ -10,8 +10,8 @@ gallery: true
 images: true
 migrateImages: false
 migrateLinks: false
-created: '2009-11-17'
-updated: '2023-11-16'
+createdAt: '2009-11-17'
+updatedAt: '2023-11-16'
 tags:
   - css
   - geraniumcms

--- a/content/blog/2009/12/joyeux-noel-et-bonne-annee-2010.md
+++ b/content/blog/2009/12/joyeux-noel-et-bonne-annee-2010.md
@@ -4,8 +4,8 @@ title: Joyeux Noël et bonne Annee 2010
 canonical: https://renoirboulanger.com/blog/2009/12/joyeux-noel-et-bonne-annee-2010/
 status: publish
 revising: true
-created: '2009-12-25'
-updated: '2013-03-27'
+createdAt: '2009-12-25'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2009/12/le-souper-du-mage.md
+++ b/content/blog/2009/12/le-souper-du-mage.md
@@ -9,8 +9,8 @@ caption: false
 gallery: false
 migrateLinks: true
 migrateImages: true
-created: '2009-12-19'
-updated: '2013-03-27'
+createdAt: '2009-12-19'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2009/12/realisation-du-site-solutions-affaires-experts-conseils-2004.md
+++ b/content/blog/2009/12/realisation-du-site-solutions-affaires-experts-conseils-2004.md
@@ -1,8 +1,8 @@
 ---
 title: Réalisation du site Solutions Affaires experts-conseils [2004]
 locale: fr-CA
-created: 2009-12-04
-updated: 2013-03-27
+createdAt: 2009-12-04
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2009/12/realisation-du-site-solutions-affaires-experts-conseils-2004/
 status: publish

--- a/content/blog/2009/12/realisation-jamais-publiee-du-site-de-savon-des-cantons-2005.md
+++ b/content/blog/2009/12/realisation-jamais-publiee-du-site-de-savon-des-cantons-2005.md
@@ -1,8 +1,8 @@
 ---
 title: Réalisation (jamais publiée) du site de Savon des Cantons [2005]
 locale: fr-CA
-created: 2009-12-12
-updated: 2013-03-27
+createdAt: 2009-12-12
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2009/12/realisation-jamais-publiee-du-site-de-savon-des-cantons-2005/
 status: publish

--- a/content/blog/2010/01/installation-dun-paradis-du-geek-pour-trois-colocataires-partie-1.md
+++ b/content/blog/2010/01/installation-dun-paradis-du-geek-pour-trois-colocataires-partie-1.md
@@ -1,8 +1,8 @@
 ---
 title: Installation d’un paradis du Geek pour trois colocataires, partie 1
 locale: fr-CA
-created: 2010-01-03
-updated: 2013-03-27
+createdAt: 2010-01-03
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2010/01/installation-dun-paradis-du-geek-pour-trois-colocataires-partie-1/
 status: publish

--- a/content/blog/2010/01/installation-dun-paradis-du-geek-pour-trois-colocataires-partie-2.md
+++ b/content/blog/2010/01/installation-dun-paradis-du-geek-pour-trois-colocataires-partie-2.md
@@ -1,8 +1,8 @@
 ---
 title: Installation d’un paradis du Geek pour trois colocataires, partie 2
 locale: fr-CA
-created: 2010-01-09
-updated: 2013-03-27
+createdAt: 2010-01-09
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2010/01/installation-dun-paradis-du-geek-pour-trois-colocataires-partie-2/
 status: publish

--- a/content/blog/2010/01/installer-php-5-3-1-sous-debian-et-ubuntu-via-un-repository-non-officiel.md
+++ b/content/blog/2010/01/installer-php-5-3-1-sous-debian-et-ubuntu-via-un-repository-non-officiel.md
@@ -1,8 +1,8 @@
 ---
 title: Installer PHP 5.3.1 sous Debian et/ou Ubuntu via un repository non officiel
 locale: fr-CA
-created: 2010-01-09
-updated: 2013-03-27
+createdAt: 2010-01-09
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2010/01/installer-php-5-3-1-sous-debian-et-ubuntu-via-un-repository-non-officiel/
 status: publish

--- a/content/blog/2010/01/le-defi-project52-un-billet-par-semaine.md
+++ b/content/blog/2010/01/le-defi-project52-un-billet-par-semaine.md
@@ -1,8 +1,8 @@
 ---
 title: Le Défi «Project52» un billet par semaine (minimum)
 locale: fr-CA
-created: 2010-01-06
-updated: 2013-03-27
+createdAt: 2010-01-06
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2010/01/le-defi-%c2%abproject52%c2%bb-un-billet-par-semaine-minimum/
 status: publish

--- a/content/blog/2010/01/le-manifeste-open-cloud-pour-standardiser-info-nuagique.md
+++ b/content/blog/2010/01/le-manifeste-open-cloud-pour-standardiser-info-nuagique.md
@@ -1,8 +1,8 @@
 ---
 title: Le Manifeste "Open Cloud" pour standardiser l'informatique «dans les nuages»
 locale: fr-CA
-created: 2010-01-02
-updated: 2013-03-27
+createdAt: 2010-01-02
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2010/01/le-manifeste-open-cloud-pour-standardiser-linformatique-%c2%abdans-les-nuages%c2%bb/
 status: publish

--- a/content/blog/2010/01/revue-de-fonctions-qui-sont-selon-moi-ideales-a-un-cms-entre-cms-made-simple-et-modx.md
+++ b/content/blog/2010/01/revue-de-fonctions-qui-sont-selon-moi-ideales-a-un-cms-entre-cms-made-simple-et-modx.md
@@ -12,8 +12,8 @@ caption: true
 migrateLinks: true
 migrateImages: true
 migrateCode: true
-created: '2010-01-12'
-updated: '2013-03-27'
+createdAt: '2010-01-12'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2010/02/crash-course-sur-les-environnements-java.md
+++ b/content/blog/2010/02/crash-course-sur-les-environnements-java.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2010/02/crash-course-sur-les-environnements-java/
 status: publish
 revising: true
-created: '2010-02-25'
-updated: '2013-03-27'
+createdAt: '2010-02-25'
+updatedAt: '2013-03-27'
 tags:
   - tutoriels
   - vulgarisation

--- a/content/blog/2010/02/plugin-modx-pour-generer-automatiquement-les-balises-abbr-et-autres-pour-chaque-page.md
+++ b/content/blog/2010/02/plugin-modx-pour-generer-automatiquement-les-balises-abbr-et-autres-pour-chaque-page.md
@@ -12,8 +12,8 @@ caption: true
 migrateLinks: true
 migrateImages: true
 migrateCode: true
-created: '2010-02-12'
-updated: '2013-03-27'
+createdAt: '2010-02-12'
+updatedAt: '2013-03-27'
 tags:
   - accessibility
   - html

--- a/content/blog/2010/02/realisation-dune-application-dechange-de-cadeau-avec-red-lagence.md
+++ b/content/blog/2010/02/realisation-dune-application-dechange-de-cadeau-avec-red-lagence.md
@@ -3,8 +3,8 @@ title: >-
   Réalisation d'une application d'échange de cadeau avec RED L'agence le «club
   échangiste» [2009]
 locale: fr-CA
-created: 2010-02-03
-updated: 2013-03-27
+createdAt: 2010-02-03
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2010/02/realisation-dune-application-dechange-de-cadeau-avec-red-lagence-le-%c2%abclub-echangiste%c2%bb-2009/
 status: publish

--- a/content/blog/2010/02/script-bash-pour-transferer-une-base-de-donnee-mysql-dun-serveur-a-lautre.md
+++ b/content/blog/2010/02/script-bash-pour-transferer-une-base-de-donnee-mysql-dun-serveur-a-lautre.md
@@ -2,8 +2,8 @@
 title:
   Script bash pour transférer une base de donnée MySQL d’un serveur à l’autre
 locale: fr-CA
-created: 2010-02-09
-updated: 2013-06-12
+createdAt: 2010-02-09
+updatedAt: 2013-06-12
 canonical: 'https://renoirboulanger.com/blog/2010/02/script-bash-pour-transferer-une-base-de-donnee-mysql-dun-serveur-a-lautre/'
 status: publish
 revising: true

--- a/content/blog/2010/03/etes-vous-victime-despionnage-via-votre-profil-dans-les-medias-sociaux.md
+++ b/content/blog/2010/03/etes-vous-victime-despionnage-via-votre-profil-dans-les-medias-sociaux.md
@@ -1,8 +1,8 @@
 ---
 title: Êtes-vous victime d’espionnage via votre profil dans les médias sociaux
 locale: fr-CA
-created: 2010-03-22
-updated: 2020-11-07
+createdAt: 2010-03-22
+updatedAt: 2020-11-07
 canonical: ’https://renoirboulanger.com/blog/2010/03/etes-vous-victime-despionnage-via-votre-profil-dans-les-medias-sociaux/'
 status: publish
 revising: true

--- a/content/blog/2010/03/introduction-de-notre-nouveau-projet-evenement-intitule-devlab.md
+++ b/content/blog/2010/03/introduction-de-notre-nouveau-projet-evenement-intitule-devlab.md
@@ -1,8 +1,8 @@
 ---
 title: DevLab Montréal — Introduction de nos événements hebdomadaire pour programmeurs
 locale: fr-CA
-created: 2010-03-17
-updated: 2013-03-27
+createdAt: 2010-03-17
+updatedAt: 2013-03-27
 canonical: 'https://renoirboulanger.com/blog/2010/03/introduction-de-notre-nouveau-projet-evenement-intitule-devlab/'
 status: publish
 revising: true

--- a/content/blog/2010/03/la-premiere-de-ignite-montreal.md
+++ b/content/blog/2010/03/la-premiere-de-ignite-montreal.md
@@ -1,8 +1,8 @@
 ---
 title: La première de Ignite Montréal
 locale: fr-CA
-created: 2010-03-03
-updated: 2013-03-27
+createdAt: 2010-03-03
+updatedAt: 2013-03-27
 canonical: https://renoirboulanger.com/blog/2010/03/la-premiere-de-ignite-montreal
 status: publish
 revising: true

--- a/content/blog/2010/04/comment-automatiser-une-tache-avec-cron-en-utilisant-vim.md
+++ b/content/blog/2010/04/comment-automatiser-une-tache-avec-cron-en-utilisant-vim.md
@@ -9,8 +9,8 @@ caption: true
 migrateLinks: true
 migrateImages: true
 migrateCode: true
-created: '2010-04-14'
-updated: '2013-03-27'
+createdAt: '2010-04-14'
+updatedAt: '2013-03-27'
 tags:
   - logiciel-libre
   - tutoriels

--- a/content/blog/2010/04/comment-dire-a-apache-le-mime-type-dun-document-office-2007.md
+++ b/content/blog/2010/04/comment-dire-a-apache-le-mime-type-dun-document-office-2007.md
@@ -7,8 +7,8 @@ status: publish
 revising: true
 migrateLinks: true
 migrateCode: true
-created: '2010-04-21'
-updated: '2013-03-27'
+createdAt: '2010-04-21'
+updatedAt: '2013-03-27'
 tags:
   - linux
   - securite

--- a/content/blog/2010/04/la-semaine-des-logiciels-libres-a-montreal-mondev.md
+++ b/content/blog/2010/04/la-semaine-des-logiciels-libres-a-montreal-mondev.md
@@ -8,8 +8,8 @@ revising: true
 caption: true
 migrateLinks: true
 migrateImages: true
-created: '2010-04-15'
-updated: '2013-03-27'
+createdAt: '2010-04-15'
+updatedAt: '2013-03-27'
 tags:
   - events
   - logiciel-libre

--- a/content/blog/2010/04/les-differentes-versions-du-service-de-taches-planifie-cron.md
+++ b/content/blog/2010/04/les-differentes-versions-du-service-de-taches-planifie-cron.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2010/04/les-differentes-versions-du-service-de-taches-planifie-cron/
 status: publish
 revising: true
-created: '2010-04-19'
-updated: '2013-03-27'
+createdAt: '2010-04-19'
+updatedAt: '2013-03-27'
 tags:
   - linux
   - outils

--- a/content/blog/2010/04/procedure-pour-creer-un-serveur-ftp-securise-ssl-force-avec-usager-virtuels-sous-ubuntu-linux-avec-vsftpd.md
+++ b/content/blog/2010/04/procedure-pour-creer-un-serveur-ftp-securise-ssl-force-avec-usager-virtuels-sous-ubuntu-linux-avec-vsftpd.md
@@ -7,8 +7,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2010/04/procedure-pour-creer-un-serveur-ftp-securise-ssl-force-avec-usager-virtuels-sous-ubuntu-linux-avec-vsftpd/
 status: publish
 revising: true
-created: '2010-04-30'
-updated: '2013-03-29'
+createdAt: '2010-04-30'
+updatedAt: '2013-03-29'
 tags:
   - linux
   - logiciel-libre

--- a/content/blog/2010/04/quelques-options-de-configuration-recurentes-pour-apache-mysql-et-php.md
+++ b/content/blog/2010/04/quelques-options-de-configuration-recurentes-pour-apache-mysql-et-php.md
@@ -1,8 +1,8 @@
 ---
 title: Quelques options de configuration récurentes pour Apache, MySQL et PHP
 locale: fr-CA
-created: 2010-04-22
-updated: 2013-03-27
+createdAt: 2010-04-22
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2010/04/quelques-options-de-configuration-recurentes-pour-apache-mysql-et-php/
 status: publish

--- a/content/blog/2010/04/realisation-du-micro-site-de-linitiative-environnementale-de-la-ville-de-sherbrooke-2006-2.md
+++ b/content/blog/2010/04/realisation-du-micro-site-de-linitiative-environnementale-de-la-ville-de-sherbrooke-2006-2.md
@@ -3,8 +3,8 @@ title: >-
   Réalisation du Micro-site de l'Initiative Environnementale de la Ville de
   Sherbrooke [2006]
 locale: fr-CA
-created: 2010-04-26
-updated: 2013-03-27
+createdAt: 2010-04-26
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2010/04/realisation-du-micro-site-de-linitiative-environnementale-de-la-ville-de-sherbrooke-2006-2/
 status: publish

--- a/content/blog/2010/04/trois-geeks-cherchent-un-nouveau-loyer-sur-montreal.md
+++ b/content/blog/2010/04/trois-geeks-cherchent-un-nouveau-loyer-sur-montreal.md
@@ -1,8 +1,8 @@
 ---
 title: Trois Geeks cherchent un nouveau Loyer sur Montréal
 locale: fr-CA
-created: 2010-04-05
-updated: 2010-04-05
+createdAt: 2010-04-05
+updatedAt: 2010-04-05
 canonical: >-
   https://renoirboulanger.com/blog/2010/04/trois-geeks-cherchent-un-nouveau-loyer-sur-montreal/
 status: publish

--- a/content/blog/2010/05/article-publie-sur-devlab-community-partner-spotlight-devlab-montreal.md
+++ b/content/blog/2010/05/article-publie-sur-devlab-community-partner-spotlight-devlab-montreal.md
@@ -3,8 +3,8 @@ title:
   'devLAB Montreal is in the Community Partner Spotlight at Microsoft’s Make Web
   Not War 2010'
 locale: en-CA
-created: 2010-05-19
-updated: 2013-03-27
+createdAt: 2010-05-19
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2010/05/article-publie-sur-devlab-community-partner-spotlight-devlab-montreal/
 status: publish

--- a/content/blog/2010/05/mise-a-jour-de-lhoraire-de-la-semaine-des-logiciels-libres-mondev-du-24-28-mai-prochain.md
+++ b/content/blog/2010/05/mise-a-jour-de-lhoraire-de-la-semaine-des-logiciels-libres-mondev-du-24-28-mai-prochain.md
@@ -3,8 +3,8 @@ title: >-
   Mise à jour de l'horaire de la semaine des logiciels libres MonDev du 24-28
   Mai prochain
 locale: fr-CA
-created: 2010-05-17
-updated: 2013-03-27
+createdAt: 2010-05-17
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2010/05/mise-a-jour-de-lhoraire-de-la-semaine-des-logiciels-libres-mondev-du-24-28-mai-prochain/
 status: publish

--- a/content/blog/2010/05/traduction-libre-de-larticle-why-the-is-microsoft-doing-all-this.md
+++ b/content/blog/2010/05/traduction-libre-de-larticle-why-the-is-microsoft-doing-all-this.md
@@ -1,8 +1,8 @@
 ---
 title: Traduction libre de l’article «Why the @&*# is Microsoft doing all this?»
 locale: fr-CA
-created: 2010-05-30
-updated: 2023-11-15
+createdAt: 2010-05-30
+updatedAt: 2023-11-15
 canonical: >-
   https://renoirboulanger.com/blog/2010/05/traduction-libre-de-larticle-why-the-is-microsoft-doing-all-this/
 status: publish

--- a/content/blog/2010/06/comment-remplacer-les-caracteres-bizzares-dans-wordpress-lorsqu-on-a-mal-fait-la-conversion.md
+++ b/content/blog/2010/06/comment-remplacer-les-caracteres-bizzares-dans-wordpress-lorsqu-on-a-mal-fait-la-conversion.md
@@ -9,8 +9,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2010-06-10'
-updated: '2013-03-29'
+createdAt: '2010-06-10'
+updatedAt: '2013-03-29'
 tags:
   - linux
   - mysql

--- a/content/blog/2010/06/retour-sur-la-semaine-des-logiciels-libres-mondev-et-de-la-conference-make-web-not-war-2010.md
+++ b/content/blog/2010/06/retour-sur-la-semaine-des-logiciels-libres-mondev-et-de-la-conference-make-web-not-war-2010.md
@@ -3,8 +3,8 @@ title: >-
   Retour sur la semaine des logiciels Libres MonDev et de la conférence Make Web
   Not War 2010
 locale: fr-CA
-created: 2010-06-22
-updated: 2013-03-27
+createdAt: 2010-06-22
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2010/06/retour-sur-la-semaine-des-logiciels-libres-mondev-et-de-la-conference-make-web-not-war-2010/
 status: publish

--- a/content/blog/2010/07/bug-trouve-et-corrige-sur-un-theme-wordpress-rttheme.md
+++ b/content/blog/2010/07/bug-trouve-et-corrige-sur-un-theme-wordpress-rttheme.md
@@ -1,8 +1,8 @@
 ---
 title: Bug trouvé et corrigé sur un thème WordPress rtTheme
 locale: fr-CA
-created: 2010-07-01
-updated: 2013-03-27
+createdAt: 2010-07-01
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2010/07/bug-trouve-et-corrige-sur-un-theme-wordpress-rttheme/
 status: publish

--- a/content/blog/2010/07/installer-une-machine-virtuelle-linux-roulant-dans-vmware-fusion-sous-mac-os-x.md
+++ b/content/blog/2010/07/installer-une-machine-virtuelle-linux-roulant-dans-vmware-fusion-sous-mac-os-x.md
@@ -7,8 +7,8 @@ status: publish
 revising: true
 caption: true
 migrateImages: true
-created: '2010-07-07'
-updated: '2023-11-16'
+createdAt: '2010-07-07'
+updatedAt: '2023-11-16'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2010/09/lancement-de-lannee-2011-pour-la-conference-confoo.md
+++ b/content/blog/2010/09/lancement-de-lannee-2011-pour-la-conference-confoo.md
@@ -1,8 +1,8 @@
 ---
 title: Lancement de l’annee 2011 pour la conférence ConFoo
 locale: fr-CA
-created: 2010-09-08
-updated: 2023-11-16
+createdAt: 2010-09-08
+updatedAt: 2023-11-16
 canonical: 'https://renoirboulanger.com/blog/2010/09/lancement-de-lannee-2011-pour-la-conference-confoo/'
 status: publish
 revising: false

--- a/content/blog/2010/09/lappel-aux-conferenciers-pour-confoo-2011-est-lance.md
+++ b/content/blog/2010/09/lappel-aux-conferenciers-pour-confoo-2011-est-lance.md
@@ -6,8 +6,8 @@ canonical: >-
 status: publish
 revising: true
 caption: true
-created: '2010-09-28'
-updated: '2023-11-16'
+createdAt: '2010-09-28'
+updatedAt: '2023-11-16'
 categories:
   - events
 tags: []

--- a/content/blog/2010/09/realisation-de-lintegration-du-site-de-jean-emond-2008.md
+++ b/content/blog/2010/09/realisation-de-lintegration-du-site-de-jean-emond-2008.md
@@ -1,8 +1,8 @@
 ---
 locale: fr-CA
 title: Réalisation de l’intégration du site de Jean Émond [2008]
-created: 2010-09-16
-updated: 2013-03-27
+createdAt: 2010-09-16
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2010/09/realisation-de-lintegration-du-site-de-jean-emond-2008/
 status: publish

--- a/content/blog/2010/09/realisation-site-manoir-saint-francis-faits-avec-geraniumcms-2007.md
+++ b/content/blog/2010/09/realisation-site-manoir-saint-francis-faits-avec-geraniumcms-2007.md
@@ -1,8 +1,8 @@
 ---
 title: Réalisation site Manoir Saint-Francis faits avec GéraniumCMS [2007]
 locale: fr-CA
-created: 2010-09-12
-updated: 2023-11-16
+createdAt: 2010-09-12
+updatedAt: 2023-11-16
 canonical: >-
   https://renoirboulanger.com/blog/2010/09/realisation-site-manoir-saint-francis-faits-avec-geraniumcms-2007/
 status: publish

--- a/content/blog/2010/12/comment-configurer-son-clavier-keymap-sous-ubuntu-linux-en-mode-terminal-seulement.md
+++ b/content/blog/2010/12/comment-configurer-son-clavier-keymap-sous-ubuntu-linux-en-mode-terminal-seulement.md
@@ -3,8 +3,8 @@ title: >-
   Comment configurer son clavier («keymap») sous Ubuntu Linux en mode terminal
   seulement
 locale: fr-CA
-created: 2010-12-08
-updated: 2024-10-05
+createdAt: 2010-12-08
+updatedAt: 2024-10-05
 canonical: >-
   https://renoirboulanger.com/blog/2010/12/comment-configurer-son-clavier-keymap-sous-ubuntu-linux-en-mode-terminal-seulement/
 status: publish

--- a/content/blog/2011/01/confoo-web-techno-conferencee-2011-devoilement-de-la-grille-horraire-des-presentations.md
+++ b/content/blog/2011/01/confoo-web-techno-conferencee-2011-devoilement-de-la-grille-horraire-des-presentations.md
@@ -7,8 +7,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2011/01/confoo-web-techno-conferencee-2011-devoilement-de-la-grille-horraire-des-presentations/
 status: publish
 revising: true
-created: '2011-01-25'
-updated: '2013-03-27'
+createdAt: '2011-01-25'
+updatedAt: '2013-03-27'
 tags: []
 categories:
 - events

--- a/content/blog/2011/02/confoo-cest-dans-moins-de-14-jours.md
+++ b/content/blog/2011/02/confoo-cest-dans-moins-de-14-jours.md
@@ -4,8 +4,8 @@ title: ConFoo c'est dans moins de 14 jours!
 canonical: https://renoirboulanger.com/blog/2011/02/confoo-cest-dans-moins-de-14-jours/
 status: publish
 revising: true
-created: '2011-02-24'
-updated: '2023-11-16'
+createdAt: '2011-02-24'
+updatedAt: '2023-11-16'
 categories:
   - events
 tags: []

--- a/content/blog/2011/02/devlab-montreal-cest-maintenant-parti.md
+++ b/content/blog/2011/02/devlab-montreal-cest-maintenant-parti.md
@@ -1,8 +1,8 @@
 ---
 title: devLAB Montréal c'est maintenant parti!
 locale: fr-CA
-created: 2011-02-08
-updated: 2023-11-16
+createdAt: 2011-02-08
+updatedAt: 2023-11-16
 canonical: https://renoirboulanger.com/blog/2011/02/devlab-montreal-cest-maintenant-parti/
 status: publish
 revising: true

--- a/content/blog/2011/03/comment-installer-ruby-on-rails-sur-ubuntu-10-10.md
+++ b/content/blog/2011/03/comment-installer-ruby-on-rails-sur-ubuntu-10-10.md
@@ -7,8 +7,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2011-03-25'
-updated: '2013-03-27'
+createdAt: '2011-03-25'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: >-

--- a/content/blog/2012/02/comment-rapidement-acceder-aux-logs-dun-environnement-de-production-symfony-1-x-en-moins-de-tapes-clavier-posible.md
+++ b/content/blog/2012/02/comment-rapidement-acceder-aux-logs-dun-environnement-de-production-symfony-1-x-en-moins-de-tapes-clavier-posible.md
@@ -7,8 +7,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2012/02/comment-rapidement-acceder-aux-logs-dun-environnement-de-production-symfony-1-x-en-moins-de-tapes-clavier-posible/
 status: publish
 revising: true
-created: '2012-02-15'
-updated: '2013-03-27'
+createdAt: '2012-02-15'
+updatedAt: '2013-03-27'
 tags:
   - symfony
   - trucs

--- a/content/blog/2012/02/creer-un-tunnel-ssh-inverse-pour-pouvoir-supporter-a-distance-un-ami-utilisant-linux.md
+++ b/content/blog/2012/02/creer-un-tunnel-ssh-inverse-pour-pouvoir-supporter-a-distance-un-ami-utilisant-linux.md
@@ -9,8 +9,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2012-02-29'
-updated: '2013-03-29'
+createdAt: '2012-02-29'
+updatedAt: '2013-03-29'
 tags:
   - linux
   - logiciel-libre

--- a/content/blog/2012/02/mon-cv-est-maintenant-en-ligne.md
+++ b/content/blog/2012/02/mon-cv-est-maintenant-en-ligne.md
@@ -4,8 +4,8 @@ title: Mon CV est maintenant en ligne
 canonical: https://renoirboulanger.com/blog/2012/02/mon-cv-est-maintenant-en-ligne/
 status: publish
 revising: true
-created: '2012-02-08'
-updated: '2023-11-16'
+createdAt: '2012-02-08'
+updatedAt: '2023-11-16'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2012/04/feuille-de-style-pour-imprimante-pour-les-pages-de-documentation-de-doctrine2-et-symfony2.md
+++ b/content/blog/2012/04/feuille-de-style-pour-imprimante-pour-les-pages-de-documentation-de-doctrine2-et-symfony2.md
@@ -10,8 +10,8 @@ revising: true
 migrateCode: true
 migrateImages: true
 migrateLinks: true
-created: '2012-04-07'
-updated: '2023-11-16'
+createdAt: '2012-04-07'
+updatedAt: '2023-11-16'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2012/04/les-diapositives-de-ma-presentation-au-html5mtl-comment-entretenir-et-utiliser-une-architecture-modulaire-et-reutilisable-css-est-publie.md
+++ b/content/blog/2012/04/les-diapositives-de-ma-presentation-au-html5mtl-comment-entretenir-et-utiliser-une-architecture-modulaire-et-reutilisable-css-est-publie.md
@@ -6,9 +6,9 @@ title: >-
 canonical: >-
   https://renoirboulanger.com/blog/2012/04/les-diapositives-de-ma-presentation-au-html5mtl-comment-entretenir-et-utiliser-une-architecture-modulaire-et-reutilisable-css-est-publie/
 status: publish
+createdAt: '2012-04-29'
+updatedAt: '2013-03-27'
 revising: true
-created: '2012-04-29'
-updated: '2013-03-27'
 tags:
   - entrepreneurial-life
   - events

--- a/content/blog/2012/05/snippet-confirm-form-before-submitting-using-twitter-bootstrap-in-a-modal-window.md
+++ b/content/blog/2012/05/snippet-confirm-form-before-submitting-using-twitter-bootstrap-in-a-modal-window.md
@@ -12,8 +12,8 @@ gallery: false
 migrateCode: true
 migrateImages: false
 migrateLinks: true
-created: '2012-05-28'
-updated: '2023-11-16'
+createdAt: '2012-05-28'
+updatedAt: '2023-11-16'
 tags:
   - favourites
   - patterns

--- a/content/blog/2012/06/how-to-implement-a-collectiontype-form-field-with-ajax-add-new-embedded-form-with-re-usable-markup-using-symfony2-and-twitter-bootstrap.md
+++ b/content/blog/2012/06/how-to-implement-a-collectiontype-form-field-with-ajax-add-new-embedded-form-with-re-usable-markup-using-symfony2-and-twitter-bootstrap.md
@@ -7,8 +7,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2012/06/how-to-implement-a-collectiontype-form-field-with-ajax-add-new-embedded-form-with-re-usable-markup-using-symfony2-and-twitter-bootstrap/
 status: publish
 revising: true
-created: '2012-06-21'
-updated: '2013-03-31'
+createdAt: '2012-06-21'
+updatedAt: '2013-03-31'
 tags:
   - jquery
   - symfony2

--- a/content/blog/2012/06/mon-souhait-pour-bien-ecrire-sur-le-web-lettre-ouverte-a-druide.md
+++ b/content/blog/2012/06/mon-souhait-pour-bien-ecrire-sur-le-web-lettre-ouverte-a-druide.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2012/06/mon-souhait-pour-bien-ecrire-sur-le-web-lettre-ouverte-a-druide/
 status: publish
 revising: true
-created: '2012-06-28'
-updated: '2013-03-31'
+createdAt: '2012-06-28'
+updatedAt: '2013-03-31'
 tags:
   - outils
   - web

--- a/content/blog/2012/06/resume-de-mes-essais-avec-composer-sous-symfony-2-0-x-et-un-manifeste-composer-json-pour-vos-propres-tests.md
+++ b/content/blog/2012/06/resume-de-mes-essais-avec-composer-sous-symfony-2-0-x-et-un-manifeste-composer-json-pour-vos-propres-tests.md
@@ -9,8 +9,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2012-06-18'
-updated: '2013-03-31'
+createdAt: '2012-06-18'
+updatedAt: '2013-03-31'
 tags:
   - php
   - symfony2

--- a/content/blog/2012/06/trying-to-find-templating-engine-library-of-markup-generating-schema-orgrdfa-content.md
+++ b/content/blog/2012/06/trying-to-find-templating-engine-library-of-markup-generating-schema-orgrdfa-content.md
@@ -7,8 +7,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2012/06/trying-to-find-templating-engine-library-of-markup-generating-schema-orgrdfa-content/
 status: publish
 revising: true
-created: '2012-06-29'
-updated: '2013-04-10'
+createdAt: '2012-06-29'
+updatedAt: '2013-04-10'
 tags:
   - symfony2
   - wish-list

--- a/content/blog/2012/07/a-quick-overview-on-the-advantages-to-architect-you-html-in-an-object-oriented-approach.md
+++ b/content/blog/2012/07/a-quick-overview-on-the-advantages-to-architect-you-html-in-an-object-oriented-approach.md
@@ -7,8 +7,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2012/07/a-quick-overview-on-the-advantages-to-architect-you-html-in-an-object-oriented-approach/
 status: publish
 revising: true
-created: '2012-07-24'
-updated: '2013-03-27'
+createdAt: '2012-07-24'
+updatedAt: '2013-03-27'
 tags:
   - architecture
   - html

--- a/content/blog/2012/07/choosing-a-framework-how-i-personally-define-what-is-hot-about-them-an-evaluation-process.md
+++ b/content/blog/2012/07/choosing-a-framework-how-i-personally-define-what-is-hot-about-them-an-evaluation-process.md
@@ -3,8 +3,8 @@ title:
   Choosing a framework, how I personally check as “hot” characteristics, my
   evaluation process
 locale: en-CA
-created: 2012-07-23
-updated: 2013-03-29
+createdAt: 2012-07-23
+updatedAt: 2013-03-29
 canonical: 'https://renoirboulanger.com/blog/2012/07/choosing-a-framework-how-i-personally-define-what-is-hot-about-them-an-evaluation-process/'
 status: publish
 revising: true

--- a/content/blog/2012/07/how-i-managed-to-make-work-guzzle-rest-client-library-under-symfony-2-0-x-as-a-bundle-snipet.md
+++ b/content/blog/2012/07/how-i-managed-to-make-work-guzzle-rest-client-library-under-symfony-2-0-x-as-a-bundle-snipet.md
@@ -9,8 +9,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2012-07-11'
-updated: '2013-03-29'
+createdAt: '2012-07-11'
+updatedAt: '2013-03-29'
 tags:
   - php
   - symfony2

--- a/content/blog/2012/07/my-current-symfony-2-0-x-favourites-vendor-dependencies.md
+++ b/content/blog/2012/07/my-current-symfony-2-0-x-favourites-vendor-dependencies.md
@@ -7,8 +7,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2012-07-04'
-updated: '2013-03-27'
+createdAt: '2012-07-04'
+updatedAt: '2013-03-27'
 tags:
   - best-practices
   - php

--- a/content/blog/2012/08/comment-je-valide-et-convertit-des-documents-html-trop-charges-ou-provenant-de-microsoft-word-en-html-valide-et-simplifie.md
+++ b/content/blog/2012/08/comment-je-valide-et-convertit-des-documents-html-trop-charges-ou-provenant-de-microsoft-word-en-html-valide-et-simplifie.md
@@ -3,8 +3,8 @@ title: >-
   Comment je valide et convertit des documents HTML trop chargés ou provenant de
   Microsoft Word en HTML valide et simplifié
 locale: fr-CA
-created: 2012-08-30
-updated: 2013-06-11
+createdAt: 2012-08-30
+updatedAt: 2013-06-11
 canonical: >-
   https://renoirboulanger.com/blog/2012/08/comment-je-valide-et-convertit-des-documents-html-trop-charges-ou-provenant-de-microsoft-word-en-html-valide-et-simplifie/
 status: publish

--- a/content/blog/2012/08/crash-course-about-how-dns-works-and-the-things-you-should-know-about-it.md
+++ b/content/blog/2012/08/crash-course-about-how-dns-works-and-the-things-you-should-know-about-it.md
@@ -7,8 +7,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2012-08-01'
-updated: '2013-03-27'
+createdAt: '2012-08-01'
+updatedAt: '2013-03-27'
 tags:
   - tutoriels
   - vulgarisation

--- a/content/blog/2012/08/ma-critique-sur-lintegration-du-site-a25-com.md
+++ b/content/blog/2012/08/ma-critique-sur-lintegration-du-site-a25-com.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2012/08/ma-critique-sur-lintegration-du-site-a25-com/
 status: publish
 revising: true
-created: '2012-08-28'
-updated: '2023-11-18'
+createdAt: '2012-08-28'
+updatedAt: '2023-11-18'
 tags: []
 categories: []
 excerpt: >-

--- a/content/blog/2012/08/my-answer-to-people-asking-whether-they-should-or-not-use-a-framework-on-their-programming-language.md
+++ b/content/blog/2012/08/my-answer-to-people-asking-whether-they-should-or-not-use-a-framework-on-their-programming-language.md
@@ -7,8 +7,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2012/08/my-answer-to-people-asking-whether-they-should-or-not-use-a-framework-on-their-programming-language/
 status: publish
 revising: true
-created: '2012-08-13'
-updated: '2013-03-27'
+createdAt: '2012-08-13'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 webarchiveSnapshots:

--- a/content/blog/2012/08/nouveau-projet-refonte-de-mon-site-en-conservant-wordpress-comme-back-office-mais-symfony2doctrine2twig-pour-generer-les-vues.md
+++ b/content/blog/2012/08/nouveau-projet-refonte-de-mon-site-en-conservant-wordpress-comme-back-office-mais-symfony2doctrine2twig-pour-generer-les-vues.md
@@ -3,8 +3,8 @@ title: >-
   Nouveau projet: Refonte de mon site en conservant WordPress comme back-office,
   mais Symfony2 / Doctrine2 / Twig pour générer les vues
 locale: fr-CA
-created: 2012-08-10
-updated: 2013-03-27
+createdAt: 2012-08-10
+updatedAt: 2013-03-27
 canonical: >-
   https://renoirboulanger.com/blog/2012/08/nouveau-projet-refonte-de-mon-site-en-conservant-wordpress-comme-back-office-mais-symfony2doctrine2twig-pour-generer-les-vues/
 status: publish

--- a/content/blog/2012/08/project-manifest-content-management-publishing-platform-to-implement-accessibility-semantic-markup-and-ease-web-publishing.md
+++ b/content/blog/2012/08/project-manifest-content-management-publishing-platform-to-implement-accessibility-semantic-markup-and-ease-web-publishing.md
@@ -7,8 +7,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2012/08/project-manifest-content-management-publishing-platform-to-implement-accessibility-semantic-markup-and-ease-web-publishing/
 status: publish
 revising: true
-created: '2012-08-10'
-updated: '2013-04-10'
+createdAt: '2012-08-10'
+updatedAt: '2013-04-10'
 tags: []
 categories: []
 excerpt: >-

--- a/content/blog/2012/08/resume-dune-discussion-et-notes-sur-ce-que-jaurai-aime-comprendre-plus-rapidement-lors-de-mon-apprentissage-symfony2-et-doctrine2.md
+++ b/content/blog/2012/08/resume-dune-discussion-et-notes-sur-ce-que-jaurai-aime-comprendre-plus-rapidement-lors-de-mon-apprentissage-symfony2-et-doctrine2.md
@@ -9,8 +9,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2012-08-10'
-updated: '2013-03-27'
+createdAt: '2012-08-10'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: >-

--- a/content/blog/2012/08/some-steps-you-can-look-for-if-you-feel-your-web-application-is-slow.md
+++ b/content/blog/2012/08/some-steps-you-can-look-for-if-you-feel-your-web-application-is-slow.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2012/08/some-steps-you-can-look-for-if-you-feel-your-web-application-is-slow/
 status: publish
 revising: true
-created: '2012-08-15'
-updated: '2013-03-27'
+createdAt: '2012-08-15'
+updatedAt: '2013-03-27'
 tags:
   - architecture
   - best-practices

--- a/content/blog/2012/08/what-is-cloud-computing-when-it-is-related-to-web-application.md
+++ b/content/blog/2012/08/what-is-cloud-computing-when-it-is-related-to-web-application.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2012/08/what-is-cloud-computing-when-it-is-related-to-web-application/
 status: publish
 revising: true
-created: '2012-08-15'
-updated: '2013-03-27'
+createdAt: '2012-08-15'
+updatedAt: '2013-03-27'
 tags:
   - architecture
   - best-practices

--- a/content/blog/2012/09/reflexion-a-voix-haute-la-realite-frustrante-des-developpeurs-dans-lindustrie-du-web.md
+++ b/content/blog/2012/09/reflexion-a-voix-haute-la-realite-frustrante-des-developpeurs-dans-lindustrie-du-web.md
@@ -7,8 +7,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2012/09/reflexion-a-voix-haute-la-realite-frustrante-des-developpeurs-dans-lindustrie-du-web/
 status: publish
 revising: true
-created: '2012-09-20'
-updated: '2013-03-27'
+createdAt: '2012-09-20'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: >-

--- a/content/blog/2012/10/my-first-introduction-to-the-hypermedia.md
+++ b/content/blog/2012/10/my-first-introduction-to-the-hypermedia.md
@@ -7,8 +7,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2012-10-27'
-updated: '2023-11-16'
+createdAt: '2012-10-27'
+updatedAt: '2023-11-16'
 tags:
   - architecture
   - web

--- a/content/blog/2012/11/a-list-of-quality-indicators-we-could-find-on-an-application-or-web-site.md
+++ b/content/blog/2012/11/a-list-of-quality-indicators-we-could-find-on-an-application-or-web-site.md
@@ -7,8 +7,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2012-11-11'
-updated: '2013-04-01'
+createdAt: '2012-11-11'
+updatedAt: '2013-04-01'
 tags:
   - architecture
   - software

--- a/content/blog/2012/11/why-would-i-not-use-my-own-framework-and-how-i-sell-usage-of-symfony2-and-other-current-php-5-3-goodies-to-my-client.md
+++ b/content/blog/2012/11/why-would-i-not-use-my-own-framework-and-how-i-sell-usage-of-symfony2-and-other-current-php-5-3-goodies-to-my-client.md
@@ -9,8 +9,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2012-11-22'
-updated: '2013-03-27'
+createdAt: '2012-11-22'
+updatedAt: '2013-03-27'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2013/02/conference-comment-evaluer-la-qualite-dun-site-web-selon-les-techniques-dintegration-web-dactualite.md
+++ b/content/blog/2013/02/conference-comment-evaluer-la-qualite-dun-site-web-selon-les-techniques-dintegration-web-dactualite.md
@@ -3,8 +3,8 @@ title:
   'Conférence: Comment évaluer le niveau de qualité d’un site web selon les
   techniques d’intégration web d’actualité'
 locale: fr-CA
-created: 2013-02-21
-updated: 2023-11-16
+createdAt: 2013-02-21
+updatedAt: 2023-11-16
 canonical: 'https://renoirboulanger.com/blog/2013/02/conference-comment-evaluer-la-qualite-dun-site-web-selon-les-techniques-dintegration-web-dactualite/'
 status: publish
 revising: true

--- a/content/blog/2013/02/jai-decide-darreter-de-participer-au-conseil-dadministration-du-w3qc.md
+++ b/content/blog/2013/02/jai-decide-darreter-de-participer-au-conseil-dadministration-du-w3qc.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2013/02/jai-decide-darreter-de-participer-au-conseil-dadministration-du-w3qc/
 status: publish
 revising: true
-created: '2013-02-14'
-updated: '2013-09-07'
+createdAt: '2013-02-14'
+updatedAt: '2013-09-07'
 tags: []
 categories: []
 excerpt: ''

--- a/content/blog/2013/03/creating-and-using-javascript-events-while-combining-events-on-two-separates-behaviors.md
+++ b/content/blog/2013/03/creating-and-using-javascript-events-while-combining-events-on-two-separates-behaviors.md
@@ -13,8 +13,8 @@ gallery: false
 migrateCode: true
 migrateImages: false
 migrateLinks: true
-created: '2013-03-29'
-updated: '2013-04-01'
+createdAt: '2013-03-29'
+updatedAt: '2013-04-01'
 categories:
   - programmation
 tags:

--- a/content/blog/2013/04/astuce-concernant-le-rafraichissement-du-contenu-des-pages-avec-utilisation-dajax.md
+++ b/content/blog/2013/04/astuce-concernant-le-rafraichissement-du-contenu-des-pages-avec-utilisation-dajax.md
@@ -13,8 +13,8 @@ gallery: false
 migrateCode: true
 migrateImages: false
 migrateLinks: false
-created: '2013-04-12'
-updated: '2013-05-24'
+createdAt: '2013-04-12'
+updatedAt: '2013-05-24'
 categories:
   - programmation
 tags:

--- a/content/blog/2013/04/encapsulate-a-ldap-dn-string-using-an-array-in-php.md
+++ b/content/blog/2013/04/encapsulate-a-ldap-dn-string-using-an-array-in-php.md
@@ -11,8 +11,8 @@ gallery: false
 migrateCode: true
 migrateImages: false
 migrateLinks: false
-created: '2013-04-01'
-updated: '2013-04-02'
+createdAt: '2013-04-01'
+updatedAt: '2013-04-02'
 categories:
   - snippet
 tags:

--- a/content/blog/2013/04/enfin-jai-refait-mon-site.md
+++ b/content/blog/2013/04/enfin-jai-refait-mon-site.md
@@ -5,8 +5,8 @@ canonical: https://renoirboulanger.com/blog/2013/04/enfin-jai-refait-mon-site/
 status: publish
 revising: true
 migrateLinks: true
-created: '2013-04-09'
-updated: '2013-05-23'
+createdAt: '2013-04-09'
+updatedAt: '2013-05-23'
 tags:
   - integration
   - symfony2

--- a/content/blog/2013/04/who-else-is-using-that-feature-flipping-thing-on-their-web-applications.md
+++ b/content/blog/2013/04/who-else-is-using-that-feature-flipping-thing-on-their-web-applications.md
@@ -11,8 +11,8 @@ gallery: true
 migrateCode: false
 migrateImages: false
 migrateLinks: true
-created: '2013-04-09'
-updated: '2013-04-09'
+createdAt: '2013-04-09'
+updatedAt: '2013-04-09'
 tags:
   - best-practices
   - development

--- a/content/blog/2013/05/procedure-environnement-developement-local-facile-a-entretenir-avec-apache.md
+++ b/content/blog/2013/05/procedure-environnement-developement-local-facile-a-entretenir-avec-apache.md
@@ -13,8 +13,8 @@ gallery: false
 migrateCode: true
 migrateImages: false
 migrateLinks: false
-created: '2013-05-23'
-updated: '2013-05-24'
+createdAt: '2013-05-23'
+updatedAt: '2013-05-24'
 tags:
   - best-practices
   - favourites

--- a/content/blog/2013/07/i-just-resigned-from-my-new-job-to-start-on-an-exciting-project.md
+++ b/content/blog/2013/07/i-just-resigned-from-my-new-job-to-start-on-an-exciting-project.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2013/07/i-just-resigned-from-my-new-job-to-start-on-an-exciting-project/
 status: publish
 revising: true
-created: '2013-07-19'
-updated: '2013-08-01'
+createdAt: '2013-07-19'
+updatedAt: '2013-08-01'
 tags:
   - favourites
 categories:

--- a/content/blog/2013/08/i-am-joining-w3c-to-work-on-the-webplatform-project.md
+++ b/content/blog/2013/08/i-am-joining-w3c-to-work-on-the-webplatform-project.md
@@ -1,8 +1,8 @@
 ---
 title: I am joining W3C to work on the WebPlatform project!
 locale: en-CA
-created: 2013-08-01
-updated: 2013-08-01
+createdAt: 2013-08-01
+updatedAt: 2013-08-01
 canonical: >-
   https://renoirboulanger.com/blog/2013/08/i-am-joining-w3c-to-work-on-the-webplatform-project/
 status: publish

--- a/content/blog/2013/08/procedure-to-create-a-re-usable-configuration-export-script-to-move-virtual-machine-configuration-to-a-new-one.md
+++ b/content/blog/2013/08/procedure-to-create-a-re-usable-configuration-export-script-to-move-virtual-machine-configuration-to-a-new-one.md
@@ -8,8 +8,8 @@ canonical: >-
 status: publish
 revising: true
 migrateCode: true
-created: '2013-08-07'
-updated: '2013-08-07'
+createdAt: '2013-08-07'
+updatedAt: '2013-08-07'
 tags:
   - linux
   - logiciel-libre

--- a/content/blog/2013/09/how-to-create-a-patch-and-ensure-it-is-applied-within-salt-stack.md
+++ b/content/blog/2013/09/how-to-create-a-patch-and-ensure-it-is-applied-within-salt-stack.md
@@ -7,8 +7,8 @@ status: publish
 revising: true
 migrateCode: true
 migrateLinks: true
-created: '2013-09-12'
-updated: '2014-02-04'
+createdAt: '2013-09-12'
+updatedAt: '2014-02-04'
 tags:
   - salt-stack
   - techniques

--- a/content/blog/2013/10/project-idea-creating-a-home-made-openstack-cluster-for-development-purposes.md
+++ b/content/blog/2013/10/project-idea-creating-a-home-made-openstack-cluster-for-development-purposes.md
@@ -5,8 +5,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2013/10/project-idea-creating-a-home-made-openstack-cluster-for-development-purposes/
 status: publish
 revising: true
-created: '2013-10-24'
-updated: '2014-02-04'
+createdAt: '2013-10-24'
+updatedAt: '2014-02-04'
 tags:
   - cloud-computing
   - development

--- a/content/blog/2014/01/processus-de-creation-dune-vm-faisant-partie-dun-parc-gere-par-salt-stack.md
+++ b/content/blog/2014/01/processus-de-creation-dune-vm-faisant-partie-dun-parc-gere-par-salt-stack.md
@@ -4,15 +4,14 @@ title: Processus de création d'une VM faisant partie d'un parc géré par Salt 
 canonical: >-
   https://renoirboulanger.com/blog/2014/01/processus-de-creation-dune-vm-faisant-partie-dun-parc-gere-par-salt-stack/
 status: publish
+createdAt: 2014-01-22
+updatedAt: 2015-03-09
 revising: true
 caption: false
 gallery: false
 migrateCode: true
 migrateImages: true
 migrateLinks: true
-created: '2014-01-22'
-updated: '2015-03-09'
-categories: []
 tags:
   - cloud-computing
   - favourites

--- a/content/blog/2014/05/choses-que-jaurai-souhaite-apprendre-plus-tot.md
+++ b/content/blog/2014/05/choses-que-jaurai-souhaite-apprendre-plus-tot.md
@@ -9,8 +9,8 @@ migrateLinks: true
 migrateImages: false
 gallery: false
 caption: false
-created: '2014-05-07'
-updated: '2014-07-04'
+createdAt: '2014-05-07'
+updatedAt: '2014-07-04'
 tags: []
 categories: []
 description: Parmi les choses que j’aurai aimé apprendre il y a cette suite règles simples

--- a/content/blog/2014/07/article-impacts-of-heartbleed.md
+++ b/content/blog/2014/07/article-impacts-of-heartbleed.md
@@ -1,8 +1,8 @@
 ---
 title: Answers I gave for an article  about the impacts of Heartbleed
 locale: en-CA
-created: 2014-07-04
-updated: 2014-07-04
+createdAt: 2014-07-04
+updatedAt: 2014-07-04
 canonical: https://renoirboulanger.com/blog/2014/07/article-impacts-of-heartbleed/
 status: publish
 revising: true

--- a/content/blog/2014/07/notes-experience-asus-dvd-sdrw-08d2s-u.md
+++ b/content/blog/2014/07/notes-experience-asus-dvd-sdrw-08d2s-u.md
@@ -7,8 +7,8 @@ status: publish
 revising: true
 images: true
 migrateLinks: true
-created: '2014-07-10'
-updated: '2014-07-10'
+createdAt: '2014-07-10'
+updatedAt: '2014-07-10'
 tags: []
 categories:
   - technologies

--- a/content/blog/2014/08/thoughts-learn-code-movement-managers-might-missing.md
+++ b/content/blog/2014/08/thoughts-learn-code-movement-managers-might-missing.md
@@ -7,8 +7,8 @@ canonical: >-
   https://renoirboulanger.com/blog/2014/08/thoughts-learn-code-movement-managers-might-missing/
 status: publish
 revising: true
-created: '2014-08-24'
-updated: '2014-08-24'
+createdAt: '2014-08-24'
+updatedAt: '2014-08-24'
 tags:
   - development
   - favourites

--- a/content/blog/2015/01/create-mariadb-cluster-replication-ssl-salt-stack.md
+++ b/content/blog/2015/01/create-mariadb-cluster-replication-ssl-salt-stack.md
@@ -1,8 +1,8 @@
 ---
 title: Create a MariaDB cluster with replication over SSL with Salt Stack
 locale: en-CA
-created: 2015-01-28
-updated: 2015-02-03
+createdAt: 2015-01-28
+updatedAt: 2015-02-03
 canonical: 'https://renoirboulanger.com/blog/2015/01/create-mariadb-cluster-replication-ssl-salt-stack/'
 status: publish
 revising: false

--- a/content/blog/2015/01/quelques-bouts-de-code-pour-automatiser-le-deploiement.md
+++ b/content/blog/2015/01/quelques-bouts-de-code-pour-automatiser-le-deploiement.md
@@ -1,8 +1,8 @@
 ---
 title: Quelques bouts de code pour automatiser le déploiement
 locale: fr-CA
-created: 2015-01-28
-updated: 2015-02-17
+createdAt: 2015-01-28
+updatedAt: 2015-02-17
 canonical: 'https://renoirboulanger.com/blog/2015/01/quelques-bouts-de-code-pour-automatiser-le-deploiement/'
 status: publish
 revising: false

--- a/content/blog/2015/02/hhvm-et-hack-ce-qui-les-distingue-de-php.md
+++ b/content/blog/2015/02/hhvm-et-hack-ce-qui-les-distingue-de-php.md
@@ -1,8 +1,8 @@
 ---
 title: HHVM et Hack; ce qui les distingue de PHP
 locale: fr-CA
-created: 2015-02-03
-updated: 2023-11-16
+createdAt: 2015-02-03
+updatedAt: 2023-11-16
 canonical: >-
   https://renoirboulanger.com/blog/2015/02/hhvm-et-hack-ce-qui-les-distingue-de-php/
 status: publish

--- a/content/blog/2015/02/install-php5-memcached-pecl-extension-support-igbinary.md
+++ b/content/blog/2015/02/install-php5-memcached-pecl-extension-support-igbinary.md
@@ -1,8 +1,8 @@
 ---
 title: Install PHP5 Memcached PECL extension and have it support igbinary
 locale: en-CA
-created: 2015-02-18
-updated: 2023-02-18
+createdAt: 2015-02-18
+updatedAt: 2023-02-18
 canonical: 'https://renoirboulanger.com/blog/2015/02/install-php5-memcached-pecl-extension-support-igbinary/'
 status: publish
 revising: false

--- a/content/blog/2015/03/creating-new-ubuntu-salt-master-terminal-using-cloud-init.md
+++ b/content/blog/2015/03/creating-new-ubuntu-salt-master-terminal-using-cloud-init.md
@@ -1,8 +1,8 @@
 ---
 title: Creating a new Ubuntu Salt master from the terminal using Cloud-Init
 locale: en-CA
-created: 2015-03-09
-updated: 2023-02-18
+createdAt: 2015-03-09
+updatedAt: 2023-02-18
 canonical: 'https://renoirboulanger.com/blog/2015/03/creating-new-ubuntu-salt-master-terminal-using-cloud-init/'
 status: publish
 revising: true

--- a/content/blog/2015/03/useful-gnulinux-truth-tests.md
+++ b/content/blog/2015/03/useful-gnulinux-truth-tests.md
@@ -1,8 +1,8 @@
 ---
 title: A few useful GNU/Linux truth tests while creating salt states
 locale: en-CA
-created: 2015-03-10
-updated: 2023-02-18
+createdAt: 2015-03-10
+updatedAt: 2023-02-18
 canonical: https://renoirboulanger.com/blog/2015/03/useful-gnulinux-truth-tests/
 status: publish
 revising: true

--- a/content/blog/2015/04/install-discourse-docker-ubuntu-14-04-aufs-enabled.md
+++ b/content/blog/2015/04/install-discourse-docker-ubuntu-14-04-aufs-enabled.md
@@ -1,8 +1,8 @@
 ---
 title: Install Discourse and Docker on Ubuntu 14.04 with aufs enabled
 locale: en-CA
-created: 2015-04-02
-updated: 2023-02-18
+createdAt: 2015-04-02
+updatedAt: 2023-02-18
 canonical: 'https://renoirboulanger.com/blog/2015/04/install-discourse-docker-ubuntu-14-04-aufs-enabled/'
 status: publish
 revising: true

--- a/content/blog/2015/04/run-oauth-identity-provider-service.md
+++ b/content/blog/2015/04/run-oauth-identity-provider-service.md
@@ -1,8 +1,8 @@
 ---
 title: How to run your own OAuth Identity provider service
 locale: en-CA
-created: 2015-04-13
-updated: 2023-02-18
+createdAt: 2015-04-13
+updatedAt: 2023-02-18
 canonical: https://renoirboulanger.com/blog/2015/04/run-oauth-identity-provider-service/
 status: publish
 revising: false

--- a/content/blog/2015/04/setting-discourse-fastly-cdn-provider-ssl.md
+++ b/content/blog/2015/04/setting-discourse-fastly-cdn-provider-ssl.md
@@ -1,8 +1,8 @@
 ---
 title: Setting up Discourse with Fastly as a CDN provider and TLS
 locale: en-CA
-created: 2015-04-29
-updated: 2023-02-18
+createdAt: 2015-04-29
+updatedAt: 2023-02-18
 canonical: https://renoirboulanger.com/blog/2015/04/setting-discourse-fastly-cdn-provider-ssl/
 status: publish
 revising: true

--- a/content/blog/2015/04/upgrade-python-2-7-9-ubuntu-14-04-lts-making-deb-package.md
+++ b/content/blog/2015/04/upgrade-python-2-7-9-ubuntu-14-04-lts-making-deb-package.md
@@ -3,8 +3,8 @@ title:
   Upgrade to Python 2.7.9 on Ubuntu 14.04 LTS and make your own .deb package
   for deployment
 locale: en-CA
-created: 2015-04-05
-updated: 2023-02-18
+createdAt: 2015-04-05
+updatedAt: 2023-02-18
 canonical: https://renoirboulanger.com/blog/2015/04/upgrade-python-2-7-9-ubuntu-14-04-lts-making-deb-package/
 status: publish
 revising: true

--- a/content/blog/2015/05/add-openstack-instance-meta-data-info-salt-grains.md
+++ b/content/blog/2015/05/add-openstack-instance-meta-data-info-salt-grains.md
@@ -1,8 +1,8 @@
 ---
 title: Add OpenStack instance meta-data info in your salt grains
 locale: en-CA
-created: 2015-05-22
-updated: 2023-11-17
+createdAt: 2015-05-22
+updatedAt: 2023-11-17
 canonical: 'https://renoirboulanger.com/blog/2015/05/add-openstack-instance-meta-data-info-salt-grains/'
 status: publish
 revising: false

--- a/content/blog/2015/05/converting-dynamic-site-static-copy.md
+++ b/content/blog/2015/05/converting-dynamic-site-static-copy.md
@@ -1,8 +1,8 @@
 ---
 title: Converting a dynamic site into static HTML documents
 locale: en-CA
-created: 2015-05-20
-updated: 2023-02-18
+createdAt: 2015-05-20
+updatedAt: 2023-02-18
 canonical: https://renoirboulanger.com/blog/2015/05/converting-dynamic-site-static-copy/
 status: publish
 revising: true

--- a/content/blog/2015/05/make-discourse-long-polling-work-behind-fastly.md
+++ b/content/blog/2015/05/make-discourse-long-polling-work-behind-fastly.md
@@ -1,8 +1,8 @@
 ---
 title: Make Discourse “long polling” work behind Fastly or Varnish
 locale: en-CA
-created: 2015-05-03
-updated: 2023-02-18
+createdAt: 2015-05-03
+updatedAt: 2023-02-18
 canonical: >-
   https://renoirboulanger.com/blog/2015/05/make-discourse-long-polling-work-behind-fastly/
 status: publish

--- a/content/blog/2015/05/run-nodejs-process-forever-within-docker-container.md
+++ b/content/blog/2015/05/run-nodejs-process-forever-within-docker-container.md
@@ -1,8 +1,8 @@
 ---
 title: Run a NodeJS process through forever from within a Docker container
 locale: en-CA
-created: 2015-05-12
-updated: 2023-02-18
+createdAt: 2015-05-12
+updatedAt: 2023-02-18
 canonical: >-
   https://renoirboulanger.com/blog/2015/05/run-nodejs-process-forever-within-docker-container/
 status: publish

--- a/content/blog/2015/07/leaving-w3c.md
+++ b/content/blog/2015/07/leaving-w3c.md
@@ -1,8 +1,8 @@
 ---
 title: Leaving W3C
 locale: en-CA
-created: 2015-07-30
-updated: 2023-02-18
+createdAt: 2015-07-30
+updatedAt: 2023-02-18
 canonical: https://renoirboulanger.com/blog/2015/07/leaving-w3c/
 status: publish
 revising: true

--- a/content/blog/2015/07/migrating-webplatform-org-mediawiki-into-git-history-and-into-markdown-files.md
+++ b/content/blog/2015/07/migrating-webplatform-org-mediawiki-into-git-history-and-into-markdown-files.md
@@ -1,8 +1,8 @@
 ---
 title: Migrating WebPlatform.org MediaWiki into Git as Markdown files
 locale: en-CA
-created: 2015-07-30
-updated: 2020-11-18
+createdAt: 2015-07-30
+updatedAt: 2020-11-18
 status: publish
 revising: true
 categories:

--- a/content/blog/2015/08/managing-pgp-private-keys-share-across-machines.md
+++ b/content/blog/2015/08/managing-pgp-private-keys-share-across-machines.md
@@ -1,8 +1,8 @@
 ---
 title: Managing my PGP/OpenPGP keys and share across many machines
 locale: en-CA
-created: 2015-08-06
-updated: 2023-02-18
+createdAt: 2015-08-06
+updatedAt: 2023-02-18
 canonical: >-
   https://renoirboulanger.com/blog/2015/08/managing-pgp-private-keys-share-across-machines/
 status: publish

--- a/content/blog/2015/08/thoughts-improving-load-resiliency-cms-driven-websites.md
+++ b/content/blog/2015/08/thoughts-improving-load-resiliency-cms-driven-websites.md
@@ -1,8 +1,8 @@
 ---
 title: Thoughts about improving load resiliency for CMS driven Websites
 locale: en-CA
-created: 2015-08-12
-updated: 2023-02-18
+createdAt: 2015-08-12
+updatedAt: 2023-02-18
 canonical: >-
   https://renoirboulanger.com/blog/2015/08/thoughts-improving-load-resiliency-cms-driven-websites/
 status: publish

--- a/content/blog/2015/11/recover-discourse-backup-change-domain-name.md
+++ b/content/blog/2015/11/recover-discourse-backup-change-domain-name.md
@@ -1,8 +1,8 @@
 ---
 title: Recover Discourse from a backup, adjust domain name
 locale: en-CA
-created: 2015-11-20
-updated: 2023-02-18
+createdAt: 2015-11-20
+updatedAt: 2023-02-18
 canonical: >-
   https://renoirboulanger.com/blog/2015/11/recover-discourse-backup-change-domain-name/
 status: publish

--- a/content/blog/2017/02/things-i-ve-worked-on-while-maintaining-webplatform-org.md
+++ b/content/blog/2017/02/things-i-ve-worked-on-while-maintaining-webplatform-org.md
@@ -1,8 +1,8 @@
 ---
 title: Things I’ve worked on in the last two years while maintaining WebPlatform.org
 locale: en-CA
-created: 2017-02-09
-updated: 2023-11-20
+createdAt: 2017-02-09
+updatedAt: 2023-11-20
 canonical: >-
   https://renoirboulanger.com/blog/2017/02/things-i-ve-worked-on-while-maintaining-webplatform-org/
 status: publish

--- a/content/blog/2020/02/data-driven-ui.md
+++ b/content/blog/2020/02/data-driven-ui.md
@@ -1,8 +1,8 @@
 ---
 title: Data Driven UI
 locale: en-CA
-created: 2020-02-04
-updated: 2020-02-04
+createdAt: 2020-02-04
+updatedAt: 2020-02-04
 status: publish
 revising: false
 categories:

--- a/content/blog/2020/02/harmonizing-how-to-bundle-and-package-features.md
+++ b/content/blog/2020/02/harmonizing-how-to-bundle-and-package-features.md
@@ -1,8 +1,8 @@
 ---
 locale: en-CA
 title: Harmonizing how to bundle and package JavaScript/ECMAScript features
-created: 2020-02-04
-updated: 2020-02-04
+createdAt: 2020-02-04
+updatedAt: 2020-02-04
 status: publish
 revising: false
 migrateCode: true

--- a/content/blog/2020/09/porting-all-my-content.md
+++ b/content/blog/2020/09/porting-all-my-content.md
@@ -1,8 +1,8 @@
 ---
 title: Porting all my content into a static-site
 locale: en-CA
-created: 2020-09-10
-updated: 2024-01-25
+createdAt: 2020-09-10
+updatedAt: 2024-10-25
 status: publish
 revising: false
 categories:

--- a/content/blog/2024/03/managing-email-aliases-with-protonmail-automatic-sorting.md
+++ b/content/blog/2024/03/managing-email-aliases-with-protonmail-automatic-sorting.md
@@ -3,8 +3,8 @@ title:
   Managing Email Aliases with ProtonMail and SimpleLogin to sort automatically
   into inbox folders based local part
 locale: en-CA
-created: 2024-03-03
-updated: 2024-03-03
+createdAt: 2024-03-03
+updatedAt: 2024-03-03
 canonical: https://renoirboulanger.com/blog/2024/03/managing-email-aliases-with-protonmail-and-simplelogin-to-sort-automatically-into-inbox-folders-based-local-part/
 status: publish
 revising: false

--- a/content/blog/2024/10/insert-custom-javascript-in-nuxt-config.md
+++ b/content/blog/2024/10/insert-custom-javascript-in-nuxt-config.md
@@ -1,8 +1,8 @@
 ---
 title: Insert ESM Module as custom script tag with contents with Nuxt v2
 locale: en-CA
-created: 2024-10-25
-updated: 2024-10-25
+createdAt: 2024-10-25
+updatedAt: 2024-10-25
 status: publish
 categories:
   - snippet

--- a/content/blog/2024/10/refonte-majeure-de-mon-site-web.md
+++ b/content/blog/2024/10/refonte-majeure-de-mon-site-web.md
@@ -2,8 +2,8 @@
 title: >-
   J’ai refait et migré tout mon site web
 locale: fr-CA
-created: 2024-10-26
-updated: 2024-10-26
+createdAt: 2024-10-26
+updatedAt: 2024-10-26
 status: draft
 categories:
   - projects

--- a/content/code-review/http-caching-basics.md
+++ b/content/code-review/http-caching-basics.md
@@ -1,8 +1,8 @@
 ---
 title: HTTP Caching basics
 locale: en-CA
-created: 2022-04-06
-updated: 2022-04-06
+createdAt: 2022-04-06
+updatedAt: 2022-04-06
 status: publish
 revising: false
 tags:

--- a/content/code-review/mocking-the-dom-during-tests.md
+++ b/content/code-review/mocking-the-dom-during-tests.md
@@ -1,8 +1,8 @@
 ---
 title: Mocking the DOM during tests
 locale: en-CA
-created: 2021-01-27
-updated: 2021-01-27
+createdAt: 2021-01-27
+updatedAt: 2021-01-27
 status: publish
 revising: false
 tags:

--- a/content/code-review/using-read-only-array-of-strings-as-source-for-type.md
+++ b/content/code-review/using-read-only-array-of-strings-as-source-for-type.md
@@ -1,8 +1,8 @@
 ---
 title: Using read-only array of strings as source for type
 locale: en-CA
-created: 2021-01-27
-updated: 2021-01-27
+createdAt: 2021-01-27
+updatedAt: 2021-01-27
 status: publish
 revising: false
 tags:

--- a/content/code-review/we-should-not-forget-await.md
+++ b/content/code-review/we-should-not-forget-await.md
@@ -1,8 +1,8 @@
 ---
 title: We should not forget await
 locale: en-CA
-created: 2021-01-27
-updated: 2021-01-27
+createdAt: 2021-01-27
+updatedAt: 2021-01-27
 status: publish
 revising: false
 tags:

--- a/content/glossary/progressive-enhancement.md
+++ b/content/glossary/progressive-enhancement.md
@@ -1,8 +1,8 @@
 ---
 title: Progressive Enhancement and/or Graceful Degradation
 locale: en-CA
-created: 2021-01-27
-updated: 2021-01-27
+createdAt: 2021-01-27
+updatedAt: 2021-01-27
 status: publish
 revising: false
 coverImage:

--- a/content/hello.md
+++ b/content/hello.md
@@ -1,8 +1,8 @@
 ---
 title: Hello, my name is Renoir Boulanger!
 locale: en-CA
-created: 2020-09-16
-updated: 2024-09-16
+createdAt: 2020-09-16
+updatedAt: 2024-09-16
 ---
 
 Hello!

--- a/content/ligne-editoriale.md
+++ b/content/ligne-editoriale.md
@@ -2,8 +2,8 @@
 title: Ligne éditoriale
 locale: fr-CA
 canonical: https://renoirboulanger.com/ligne-editoriale/
-created: 2009-09-19
-updated: 2013-03-30
+createdAt: 2009-09-19
+updatedAt: 2013-03-30
 status: publish
 revising: true
 pageKey: page-editorial-guideline

--- a/content/projects/les-arnaques-sur-internet.md
+++ b/content/projects/les-arnaques-sur-internet.md
@@ -1,8 +1,8 @@
 ---
 title: Les arnaques sur Internet et s’aider à les reconnaître
 locale: fr-CA
-created: 2013-04-19
-updated: 2013-04-19
+createdAt: 2013-04-19
+updatedAt: 2013-04-19
 status: publish
 revising: true
 pageKey: page-projets-initiale-pour-faire-une-migration

--- a/content/projects/script-bash-pour-transferer-une-base-de-donnee-mysql-dun-serveur-a-lautre.md
+++ b/content/projects/script-bash-pour-transferer-une-base-de-donnee-mysql-dun-serveur-a-lautre.md
@@ -2,8 +2,8 @@
 title:
   Script bash pour transférer une base de donnée MySQL d’un serveur à l’autre
 locale: fr-CA
-created: 2010-02-19
-updated: 2010-02-19
+createdAt: 2010-02-19
+updatedAt: 2010-02-19
 status: publish
 revising: true
 pageKey: page-projets-initiale-pour-faire-une-migration

--- a/content/projects/script-to-help-compare-same-page-between-two-versions.md
+++ b/content/projects/script-to-help-compare-same-page-between-two-versions.md
@@ -2,8 +2,8 @@
 title: >-
   Compare The Same Page Between Two Versions Of The Same Site Prior Rolling Out
 locale: en-CA
-created: 2024-10-12
-updated: 2024-10-12
+createdAt: 2024-10-12
+updatedAt: 2024-10-12
 status: draft
 revising: true
 excerpt: >-

--- a/content/projects/sequence-generator.md
+++ b/content/projects/sequence-generator.md
@@ -1,8 +1,8 @@
 ---
 title: Générateur de séquence
 locale: fr-CA
-created: 2013-02-19
-updated: 2013-02-19
+createdAt: 2013-02-19
+updatedAt: 2013-02-19
 status: publish
 revising: true
 pageKey: page-projets-initiale-pour-faire-une-migration

--- a/content/projets/les-arnaques-sur-internet/index.md
+++ b/content/projets/les-arnaques-sur-internet/index.md
@@ -1,8 +1,8 @@
 ---
 title: Les arnaques sur Internet
 locale: fr-CA
-created: 2011-08-04
-updated: 2023-02-22
+createdAt: 2011-08-04
+updatedAt: 2023-02-22
 canonical: 'https://renoirboulanger.com/projets/les-arnaques-sur-internet/'
 status: publish
 revising: true

--- a/content/projets/les-arnaques-sur-internet/type-descroquerie-sur-le-web-faire-du-bruit-pour-avoir-des-vues-de-page-de-medias-sociaux.md
+++ b/content/projets/les-arnaques-sur-internet/type-descroquerie-sur-le-web-faire-du-bruit-pour-avoir-des-vues-de-page-de-medias-sociaux.md
@@ -3,8 +3,8 @@ title:
   'Type d’escroquerie sur le web: Faire du bruit pour avoir des vues de page de
   médias sociaux'
 locale: fr-CA
-created: 2013-06-06
-updated: 2013-06-06
+createdAt: 2013-06-06
+updatedAt: 2013-06-06
 canonical: 'https://renoirboulanger.com/projets/les-arnaques-sur-internet/type-descroquerie-sur-le-web-faire-du-bruit-pour-avoir-des-vues-de-page-de-medias-sociaux/'
 status: publish
 revising: true

--- a/lib/model/content/break-into-years.ts
+++ b/lib/model/content/break-into-years.ts
@@ -16,17 +16,17 @@ export const extractYearFromDateString = (dateString: string | ''): number => {
 }
 
 export const extractYearFromRecord = (
-  content: Record<'created' | 'updated', string>,
+  content: Record<'createdAt' | 'updatedAt', string>,
 ): number => {
   let out: number = 0
 
-  const { created = '', updated } = content
+  const { createdAt = '', updatedAt } = content
 
-  if (created !== '') {
-    out = extractYearFromDateString(created)
+  if (createdAt !== '') {
+    out = extractYearFromDateString(createdAt)
   }
-  if (out === 0 && updated) {
-    out = extractYearFromDateString(updated)
+  if (out === 0 && updatedAt) {
+    out = extractYearFromDateString(updatedAt)
   }
 
   return out
@@ -58,5 +58,5 @@ export const breakIntoYears = (
   // Make sure it's sorted by year, chronologically
   return out.filter(([y]) => y !== 0).sort((a, b) => b[0] - a[0])
   //                         ^^^^^^^
-  //                         | We set all with no created date into a bucket aside and don't display them.
+  //                         | We set all with no createdAt date into a bucket aside and don't display them.
 }

--- a/lib/model/content/model.ts
+++ b/lib/model/content/model.ts
@@ -24,23 +24,16 @@ export interface IBaseNuxtContentResult extends IResult {
   /**
    * Nuxt internal file creation date
    *
-   * #ToLearn: Figure Out Unsure if it's filesystem
+   * Hard-coded, per file, desired publication date.
+   * If it's in the file (i.e. hardcoded), otherwise Nuxt will take from the filesystem.
    */
   createdAt: string
   /**
    * Nuxt internal file updated date
    *
-   * #ToLearn: Figure Out Unsure if it's filesystem
+   * If it's in the file (i.e. hardcoded), otherwise Nuxt will take from the filesystem.
    */
   updatedAt: string
-  /**
-   * Hard-coded, per file, desired publication date.
-   */
-  created: string
-  /**
-   * Hard-coded, per file, desired last updated date.
-   */
-  updated: string
   dir: string
   extension: string
   path: string
@@ -102,7 +95,7 @@ export type INuxtContentPrevNext = Pick<
 export interface INuxtContentIndexResult
   extends Pick<
     INuxtContentResult,
-    'created' | 'updated' | 'locale' | 'path' | 'slug' | 'title'
+    'createdAt' | 'updatedAt' | 'locale' | 'path' | 'slug' | 'title'
   > {
   prettyfiedTemporalDate?: IPrettyfiedTemporalDate
 }
@@ -138,6 +131,8 @@ export const isNuxtContentResult = (
 export const queryNuxtContent = async (
   $content: Context['$content'],
   route: Context['route'],
+  year?: string,
+  month?: string,
 ): Promise<INuxtContentResult[]> => {
   let contents: INuxtContentResult[] = []
   const { query = {} as Context['route']['query'] } = route
@@ -157,7 +152,7 @@ export const queryNuxtContent = async (
   let ds = $content('blog', { deep: true })
     .sortBy('created', 'desc')
     .only([
-      'created',
+      'createdAt',
       'excerpt',
       'locale',
       'path',
@@ -166,7 +161,7 @@ export const queryNuxtContent = async (
       'slug',
       'tags',
       'title',
-      'updated',
+      'updatedAt',
     ])
   if (q) {
     ds = ds.search(q)

--- a/lib/model/date.ts
+++ b/lib/model/date.ts
@@ -71,7 +71,7 @@ export const formatTemporal = (
 }
 
 export const getPrettyfiedTemporalDate = (
-  content: Record<'created' | 'updated', string>,
+  content: Record<'createdAt' | 'updatedAt', string>,
   locale = 'fr-CA',
   format?: Intl.DateTimeFormatOptions,
 ): IPrettyfiedTemporalDate => {
@@ -83,7 +83,7 @@ export const getPrettyfiedTemporalDate = (
    *
    * @TODO #23 It MUST be a string that has no Z in its notation.
    */
-  let field = content?.date ?? content?.created ?? content?.updated ?? 0
+  let field = content?.date ?? content?.createdAt ?? content?.updatedAt ?? 0
 
   if (/\d\d\d\d-\d\d-\d\dT/.test(field)) {
     field = field.split('T')[0]

--- a/lib/runtime/nuxt-feed.ts
+++ b/lib/runtime/nuxt-feed.ts
@@ -11,13 +11,11 @@ const EXAMPLE_NUXT_CONTENT_RESULT: Partial<INuxtContentResult>[] = [
     title:
       'Things I’ve worked on in the last two years while maintaining WebPlatform.org',
     locale: 'en-CA',
-    created: '2017-02-09T00:00:00.000Z',
-    updated: '2023-11-20T00:00:00.000Z',
+    createdAt: '2017-02-09T00:00:00.000Z',
+    updatedAt: '2023-11-20T00:00:00.000Z',
     dir: '/blog/2017/02',
     path: '/blog/2017/02/things-i-ve-worked-on-while-maintaining-webplatform-org',
     slug: 'things-i-ve-worked-on-while-maintaining-webplatform-org',
-    createdAt: '2024-10-01T17:48:55.423Z',
-    updatedAt: '2024-10-01T17:48:55.424Z',
   },
 ]
 
@@ -36,14 +34,16 @@ const baseUrlNoTrailingSlash = (u: string): string => {
 
 let failedDatesOnce = false
 
-const dateStringToDateObject = (created, tz) => {
+const dateStringToDateObject = (createdAt, tz) => {
   // #TODO Make sure we return with proper time offset for Montreal, not UTC
-  const createdNormalized =
-    !!created && !created.includes('T') ? created + 'T00:00:00.000Z' : created
+  const createdAtNormalized =
+    !!createdAt && !createdAt.includes('T')
+      ? createdAt + 'T00:00:00.000Z'
+      : createdAt
   let published: Date | undefined
   let instant
   try {
-    instant = Temporal.Instant.from(createdNormalized)
+    instant = Temporal.Instant.from(createdAtNormalized)
     instant = instant.toZonedDateTimeISO(tz)
     published = new Date(instant.epochMilliseconds)
   } catch {
@@ -102,10 +102,10 @@ export const createNuxtFeedCreate =
 
     // ------ BEGIN [ /blog ] ------------------------------
     const ds1 = $content('blog', { deep: true })
-      .sortBy('created', 'desc')
+      .sortBy('createdAt', 'desc')
       .only([
         'categories',
-        'created',
+        'createdAt',
         'description',
         'dir',
         'excerpt',
@@ -115,7 +115,7 @@ export const createNuxtFeedCreate =
         'slug',
         'tags',
         'title',
-        'updated',
+        'updatedAt',
       ])
     const p1 = (await ds1.fetch()) as INuxtContentResult[]
     all.push(
@@ -127,9 +127,9 @@ export const createNuxtFeedCreate =
 
     // ------ BEGIN [ /code-review ] ------------------------------
     const ds2 = $content('code-review', { deep: true })
-      .sortBy('created', 'desc')
+      .sortBy('createdAt', 'desc')
       .only([
-        'created',
+        'createdAt',
         'description',
         'excerpt',
         'locale',
@@ -138,7 +138,7 @@ export const createNuxtFeedCreate =
         'slug',
         'tags',
         'title',
-        'updated',
+        'updatedAt',
       ])
     const p2 = (await ds2.fetch()) as INuxtContentResult[]
     all.push(...p2)
@@ -146,9 +146,9 @@ export const createNuxtFeedCreate =
 
     // ------ BEGIN [ /glossary ] ------------------------------
     const ds3 = $content('glossary', { deep: true })
-      .sortBy('created', 'desc')
+      .sortBy('createdAt', 'desc')
       .only([
-        'created',
+        'createdAt',
         'description',
         'excerpt',
         'locale',
@@ -157,7 +157,7 @@ export const createNuxtFeedCreate =
         'slug',
         'tags',
         'title',
-        'updated',
+        'updatedAt',
       ])
     const p3 = (await ds3.fetch()) as INuxtContentResult[]
     all.push(...p3)
@@ -184,17 +184,17 @@ export const createNuxtFeedCreate =
       }
       */
 
-      const published = dateStringToDateObject(article.created, timeZone)
+      const published = dateStringToDateObject(article.createdAt, timeZone)
       if (published) {
         Reflect.set(item, 'published', published)
       } else {
         failedDates.push({
           path: article.path,
-          propertyName: 'article.created',
-          value: article.created,
+          propertyName: 'article.createdAt',
+          value: article.createdAt,
         })
       }
-      const updated = dateStringToDateObject(article.updated, timeZone)
+      const updated = dateStringToDateObject(article.updatedAt, timeZone)
       if (updated) {
         // Because "date" field is for updated
         Reflect.set(item, 'date', updated)
@@ -202,7 +202,7 @@ export const createNuxtFeedCreate =
         failedDates.push({
           path: article.path,
           propertyName: 'article.updated',
-          value: article.updated,
+          value: article.updatedAt,
         })
       }
 

--- a/pages/blog/_year/_month/_slug.vue
+++ b/pages/blog/_year/_month/_slug.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="pages__blog__year__month__slug--item">
-    <div :key="content.slug + '--' + content.created">
+    <div :key="content.slug + '--' + content.createdAt">
       <keep-alive>
         <app-very-old-article
           :preamble="preamble"
           :locale="content.locale || 'en-CA'"
-          :date="content.created"
+          :date="content.createdAt"
           class="my-4"
           alert-type="warn"
           role="alert"
@@ -198,7 +198,7 @@
            * Ideally, should:
            * - Be `status: publish`
            * - Not have a `redirect: #####`
-           * - At the neighbooring published date
+           * - At the neighbooring published (createdAt) date
            *
            * [1]: ~/blog/2015/11/recover-discourse-backup-change-domain-name
            * [2]: ~/blog/2024/03/managing-email-aliases-with-protonmail-and-simplelogin-to-sort-automatically-into-inbox-folders-based-local-part
@@ -206,8 +206,8 @@
            */
         })
         .only(['title', 'path', 'locale'])
-        .sortBy('created', 'asc')
         .surround(slug)
+        .sortBy('createdAt', 'asc')
 
       const items = await dal.fetch()
       const [prev, next] = items

--- a/pages/blog/_year/_month/index.vue
+++ b/pages/blog/_year/_month/index.vue
@@ -36,24 +36,15 @@
     components: {
       'blog-list-model-by-year': BlogListModelByYear,
     },
-    async asyncData({ $content, params }) {
-      const { year, month } = params
-
+    async asyncData({ $content, route, params }) {
       let contents: INuxtContentIndexResult[] = []
       try {
-        contents = await $content('blog', year, month, { deep: true })
-          .sortBy('created', 'desc')
-          .only([
-            'created',
-            'excerpt',
-            'locale',
-            'path',
-            'slug',
-            'tags',
-            'title',
-            'updated',
-          ])
-          .fetch()
+        contents = await queryNuxtContent(
+          $content,
+          route,
+          params.year,
+          params.month,
+        )
       } catch (_) {
         // ...
       }

--- a/pages/blog/_year/index.vue
+++ b/pages/blog/_year/index.vue
@@ -36,25 +36,10 @@
     components: {
       'blog-list-model-by-year': BlogListModelByYear,
     },
-    async asyncData({ $content, params }) {
-      const { year } = params
-
+    async asyncData({ $content, route, params }) {
       let contents: INuxtContentIndexResult[] = []
       try {
-        contents = await $content('blog', year, { deep: true })
-          .sortBy('created', 'desc')
-          .only([
-            'created',
-            'excerpt',
-            'locale',
-            'path',
-            'preamble',
-            'slug',
-            'tags',
-            'title',
-            'updated',
-          ])
-          .fetch()
+        contents = await queryNuxtContent($content, route, params.year)
       } catch (_) {
         // ..
       }

--- a/pages/blog/reviewing.vue
+++ b/pages/blog/reviewing.vue
@@ -106,8 +106,8 @@
     } else if (aProp1 < bProp1) {
       return 1
     }
-    const aProp2 = a.created.split('T')[0]
-    const bProp2 = b.created.split('T')[0]
+    const aProp2 = a.createdAt.split('T')[0]
+    const bProp2 = b.createdAt.split('T')[0]
     if (aProp2 > bProp2) {
       return -1
     } else if (aProp2 < bProp2) {
@@ -133,7 +133,7 @@
           'toc',
           'waybackMachineSnapshots',
         ])
-        .sortBy('created', 'asc')
+        .sortBy('createdAt', 'asc')
       const fetched = (await ds.fetch()) as NuxtContentResult[]
       const contents: NuxtContentResult[] = fetched
         .filter((a) => findExcludingRedirectPredicate(a))

--- a/pages/glossary/index.vue
+++ b/pages/glossary/index.vue
@@ -44,7 +44,7 @@
       try {
         contents = await $content(contentFirstDirName)
           .sortBy('title', 'desc')
-          .only(['created', 'updated', 'locale', 'path', 'slug', 'title'])
+          .only(['createdAt', 'updatedAt', 'locale', 'path', 'slug', 'title'])
           .fetch()
       } catch (_) {
         // ..

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,7 +14,7 @@
               path: content.path,
               meta: {
                 locale: content.locale ? content.locale : 'en-CA',
-                date: content.date,
+                date: content.createdAt,
               },
             }"
             class="font-serif italic no-underline"
@@ -67,7 +67,7 @@
       const db = $content('blog', { deep: true })
         .where({ tags: { $contains: tag } })
         .limit(4)
-        .sortBy('created', 'desc')
+        .sortBy('createdAt', 'desc')
       contents = await db.fetch()
 
       for (const content of contents) {

--- a/pages/projects/index.vue
+++ b/pages/projects/index.vue
@@ -81,7 +81,10 @@
     watchQuery: true,
     async asyncData({ $content, route }) {
       const q = route.query.q
-      let query = $content('projects', { deep: true }).sortBy('created', 'desc')
+      let query = $content('projects', { deep: true }).sortBy(
+        'createdAt',
+        'desc',
+      )
       if (q) {
         query = query.search(q)
         // OR query = query.search('title', q)

--- a/pages/projets/index.vue
+++ b/pages/projets/index.vue
@@ -85,7 +85,7 @@
 
       const query = $content('projects', { deep: true })
         .where({ pageKey: { $contains: pageKey }, locale: { $eq: pageLocale } })
-        .sortBy('created', 'desc')
+        .sortBy('createdAt', 'desc')
       const contents = (await query.fetch()) as INuxtContentResult[]
 
       return {


### PR DESCRIPTION
Because the fact that I want to use Obsidian to edit markdown files doesn't require me to have to use 'updated' and 'created' front matter to be kept up to date by Obsidian for me, versus the weight to handle Nuxt' page publication.