### PR TITLE
Make-use of Archivator to allow making reference from the blog for long term use

### DIFF
--- a/content/archivator/blog-clippings/archive.salon.com/politics/feature/2001/01/20/protests/print/index.md
+++ b/content/archivator/blog-clippings/archive.salon.com/politics/feature/2001/01/20/protests/print/index.md
@@ -1,0 +1,149 @@
+---
+title: Thousands protest Bush’s Inauguration
+archivedAd: 2003-11-20
+createdAt: 2024-10-23
+source: Internet Web Archive
+canonical: >-
+  https://web.archive.org/web/20031120144047/http://archive.salon.com/politics/feature/2001/01/20/protests/print.html
+---
+
+Thousands protest Bush's Inauguration
+
+Demonstrators lining the parade route give the new presidential limo an
+unwelcome splash on its way to the White House.
+
+**By Daryl Lindsey**
+
+Jan. 20, 2001 | WASHINGTON -- Not since
+[Richard Nixon](https://web.archive.org/web/20031120144047/http://archive.salon.com/directory/topics/richard_nixon/)
+paraded down Pennsylvania Avenue in 1973 has a presidential Inauguration drawn
+so many protesters -- and last time, people were out to protest the Vietnam War.
+
+Demonstrators turned out in droves on Saturday -- a miserably gray and drizzly
+day, with temperatures hovering in the mid-30s -- to protest the
+[Inauguration](https://web.archive.org/web/20031120144047/http://archive.salon.com/politics/feature/2001/01/20/speech)
+of
+[President George W. Bush,](https://web.archive.org/web/20031120144047/http://archive.salon.com/directory/topics/george_w_bush/)
+whose election was contested all the way to the Supreme Court. Police would not
+estimate the size of the crowd, but many thousands of protesters were in
+evidence.
+
+"The level of people on the streets shows that people are really upset about
+lack of democratic process," says Liz Butler of the
+[Justice Action Movement,](https://web.archive.org/web/20031120144047/http://www.inaugurauction.org/)
+the umbrella organizing committee responsible for the protest. "They took it to
+the streets. We saw tens of thousands. We saw far more protesting Bush than
+supporting him."
+
+They came out in scores, co-existing on the parade route with supporters of the
+new president and lining Pennsylvania Avenue from the Capitol to the White
+House. Interspersed between Bush-Cheney signs and Texas flags were thousands of
+protest placards, bearing inscriptions such as "Bush Cheated," "Hail to the
+Thief," "Selected not elected," "Bushwhacked by the Supremes" and "Golly Jeb, we
+pulled it off!" There were also plenty of R-rated signs, like "Dick and Bush"
+and "George Wanker Bush." One poster included a caricature of a metaphorically
+toothless Bush in the image of Alfred E. Neuman.
+
+The protesters were a who's-who of lefty causes -- from feminism and the
+pro-choice movement to
+[anti-death penalty](https://web.archive.org/web/20031120144047/http://archive.salon.com/directory/topics/death_penalty/index.html)
+protesters (identifiable by their ubiquitous
+["Free Mumia"](https://web.archive.org/web/20031120144047/http://archive.salon.com/news/feature/1999/12/21/mumia/index.html)
+garb), gay rights activists and
+[environmentalists.](https://web.archive.org/web/20031120144047/http://archive.salon.com/directory/topics/environment/index.html)
+There were also dozens of youth wearing the vinegar-soaked, tear gas- and pepper
+spray-resistant bandanas that have become a symbol of the protest movement's
+anarchist elements. But there was no one rappelling off buildings, nor any of
+the random acts of violence against global corporate outposts that characterized
+the
+[Battle of Seattle](https://web.archive.org/web/20031120144047/http://archive.salon.com/directory/topics/battle_of_seattle/index.html)
+just over a year ago.
+
+One sign underlined the irony of the number of protesters who attended the
+parade Saturday: "From nadir to Nader in 2004." Indeed, many of the protesters
+were also supporters of
+[Ralph Nader's](https://web.archive.org/web/20031120144047/http://archive.salon.com/directory/topics/ralph_nader/)
+failed presidential bid. Where he did succeed, however, was in winning 2 percent
+of the Florida vote that arguably would have gone to Gore. In other words, many
+of the demonstrators who turned out were actually protesting a president who
+they helped to deliver to the White House.
+
+The best explanation for Saturday's relative calm was that protesters were
+distributed widely along the parade route -- the police did an effective job of
+isolating protesters and the general public in small clusters along Pennsylvania
+Avenue, drastically reducing the threat of riots or violence.
+
+But this also meant there was a steady stream of heckling of Bush and Cheney as
+they moved along the broad boulevard toward the White House. And it wasn't
+entirely without incident. There were a few minor altercations between
+protesters and police. The AP reported that in one incident, impatient
+protesters who wanted to get closer to the parade route slashed tires on cars
+before getting arrested.
+
+The hatred was palpable. At one particularly dark moment, a protester lobbed an
+egg at the presidential limo. Bush remained safely inside until the final block
+before reaching his new home. (In the past,
+[Bush's father](https://web.archive.org/web/20031120144047/http://archive.salon.com/directory/topics/president_bush/)
+and even Bill Clinton walked large stretches of the parade route, but not so
+during this cold and contentious day.)
+
+During Bush's swearing-in, officers briefly detained several thousand
+protesters, some who had gathered near the Justice Department for a
+[National Organization for Women rally](https://web.archive.org/web/20031120144047/http://63.111.42.146/ca/a_article.asp?ArticleID=7109)
+and others who had marched with filmmaker and celebrity Nader endorser
+[Michael Moore](https://web.archive.org/web/20031120144047/http://archive.salon.com/directory/topics/michael_moore/)
+from the city's Dupont Circle neighborhood. The group was ultimately allowed to
+proceed down to the parade route, and a crisis was averted.
+
+The biggest single pocket of protesters was at Freedom Plaza, near the
+intersection of 14th Street and Pennsylvania Avenue. Hundreds of protesters
+gathered there, as did a passel of police wearing padded black riot gear. There
+were also Secret Service men, identifiable by their signature ear pieces, and
+G-men. But the only real violence appeared in the fervor with which protesters
+sought to project their voices. They chanted and they chanted. "We won't go
+back, send Bush back." "U.S. Navy out of Vieques." "Free Mumia." "We want Bush
+out of D.C." "Racist, sexist, anti-gay, Bush and Cheney go away!" "Georgie go
+home, Georgie go home." "You're not our president." And so on. Sadly, due to
+strict regulations set forth by the feds and Washington police, the oversize
+puppets that had lent a sense of street theater to other protests during the
+past year were largely absent this time around.
+
+The protesters at Freedom Plaza hissed, howled, booed and jeered at President
+Bush as his limousine rolled by at around 3:30 p.m. EST. The cacophony was
+deafening -- and it was no doubt heard by the President and first lady Laura
+Bush.
+
+This Inauguration enlisted the greatest amount of security ever, with thousands
+of cops on hand. Officers were called in from every police department in the
+District of Columbia -- the Supreme Court police, the National Park police, the
+Capitol police, the FBI, the Bureau of Alcohol, Tobacco and Firearms and every
+single officer of Washington's Metropolitan Police Department. Police officers
+from Maryland and Virginia were also on hand to help.
+
+A spokesperson for the Metropolitan Police Department said that as of 5:30 p.m.
+EST, only 9 arrests had been made -- all for disorderly conduct. Police reported
+no serious injuries, though several officers were hurt when protesters chucked
+bottles at them. By contrast, more than 1,300 were arrested during the
+[IMF and World Bank protests](https://web.archive.org/web/20031120144047/http://www.salon.com/news/special/wto/index.html)
+in Washington last April. About 600 were arrested during the Battle of Seattle
+on Nov. 20, 1999.
+
+Despite the low number of arrests, protest organizers accused the police
+department of acting too aggressively. "They kept protesters from joining each
+other. They used intimidation tactics to try to stop the protests. We see this
+as an extension of the Bush presidency," says JAM's Butler. "Ultimately, it's a
+culmination of corporate control in America."
+
+Nonetheless, Butler says she was pleased with turnout -- especially as inclement
+weather has dampened the overall turnout at Bush's Inaugural weekend
+festivities. "This is a historic moment," she said. "We're hearing reports that
+this is even larger than the protests against Nixon. We're incredibly excited at
+the amount of people who turned out.
+
+"Of course, we're ashamed that Bush has decided to be a 'uniter' by uniting
+people against him," Bulter continued. "They all chose to come out in the
+freezing rain -- even the weather couldn't stop these people."
+
+---
+
+_About the writer_: **Daryl Lindsey** is associate editor of Salon News.

--- a/content/archivator/blog-clippings/index.csv
+++ b/content/archivator/blog-clippings/index.csv
@@ -1,0 +1,2 @@
+https://livinginternet.com/w/wi_browse.htm;.wrap .main .grid-container
+http://archive.salon.com/politics/feature/2001/01/20/protests/print.html


### PR DESCRIPTION
Instead of making links to external links directly, when I want to add comments I'd like to have a canonical copy of a page at a given date.

I'd like sometimes to add comments, and add annotations. Maybe not for my oldest posts, but for newer ones.

Some articles I've read and appreciated years back ago are no longer online. That'll be perfect use case of using one of my projects: Archivator.