### PR TITLE
What's up with CloudFlare _redirects and URLs with and without trailing slashes?

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -37,42 +37,42 @@
 #
 # PAGES KNOWN NOT TO BE IN USE ----------
 #
-/home/ /blog/ 301
-/fr/me-joindre/ /contact/ 302
-/me-joindre/ /contact/ 302
-/renoir-boulanger/ /about/ 301
-/about/renoirb-2/ /about/ 301
+/home /blog/ 301
+/fr/me-joindre /contact/ 302
+/me-joindre /contact/ 302
+/renoir-boulanger /about/ 301
+/about/renoirb-2 /about/ 301
 #
 # DELETED ----------
 #
-/blog/2009/09/appel-a-l%e2%80%99aide-pour-animer-avec-jeunes-9-11-ans/ /error/?c=gone 301
-/blog/2010/04/trois-geeks-cherchent-un-nouveau-loyer-sur-montreal/ /error/?c=gone 301
-/screenshot/ /error/?c=gone
-/github/ /error/?c=gone
-/forrst/ /error/?c=gone
+/blog/2009/09/appel-a-l%e2%80%99aide-pour-animer-avec-jeunes-9-11-ans /error/?c=gone 301
+/blog/2010/04/trois-geeks-cherchent-un-nouveau-loyer-sur-montreal /error/?c=gone 301
+/screenshot /error/?c=gone
+/github /error/?c=gone
+/forrst /error/?c=gone
 #
 # REWRITING URL TO SOMETHING BETTER ----------
 #
-/blog/2009/08/inexis-net-2004-sur-flickr/ /blog/2009/08/realisation-site-web-inexis-solution-web-2004/ 301
-/blog/2009/11/realisation-du-site-et-de-limage-«branding»-de-beebox-2008/ /blog/2009/11/realisation-du-site-et-de-image-produit-de-beebox/ 301
-/blog/2009/11/realisation-du-site-et-de-limage-%c2%abbranding%c2%bb-de-beebox-2008/ /blog/2009/11/realisation-du-site-et-de-image-produit-de-beebox/ 301
-/blog/2010/01/le-defi-«project52»-un-billet-par-semaine-minimum/ /blog/2010/01/le-defi-project52-un-billet-par-semaine/ 301
-/blog/2010/01/le-defi-%c2%abproject52%c2%bb-un-billet-par-semaine-minimum/ /blog/2010/01/le-defi-project52-un-billet-par-semaine/ 301
-/blog/2010/01/le-manifeste-open-cloud-pour-standardiser-linformatique-«dans-les-nuages»/ /blog/2010/01/le-manifeste-open-cloud-pour-standardiser-info-nuagique/ 301
-/blog/2010/01/le-manifeste-open-cloud-pour-standardiser-linformatique-%c2%abdans-les-nuages%c2%bb/ /blog/2010/01/le-manifeste-open-cloud-pour-standardiser-info-nuagique/ 301
-/blog/2010/02/realisation-dune-application-dechange-de-cadeau-avec-red-lagence-le-«club-echangiste»-2009/ /blog/2010/02/realisation-dune-application-dechange-de-cadeau-avec-red-lagence/ 301
-/blog/2010/02/realisation-dune-application-dechange-de-cadeau-avec-red-lagence-le-%c2%abclub-echangiste%c2%bb-2009/ /blog/2010/02/realisation-dune-application-dechange-de-cadeau-avec-red-lagence/ 301
-/blog/2013/07/i-am-joining-w3c-to-work-on-the-webplatform-project/ /blog/2013/08/i-am-joining-w3c-to-work-on-the-webplatform-project/ 301
-/blog/2013/07/i-am-joining-w3c-to-work-on-the-webplatform-project-2/ /blog/2013/08/i-am-joining-w3c-to-work-on-the-webplatform-project/ 301
-/blog/2024/03/managing-email-aliases-with-protonmail-and-simplelogin-to-sort-automatically-into-inbox-folders-based-local-part/ /blog/2024/03/managing-email-aliases-with-protonmail-automatic-sorting/ 301
+/blog/2009/08/inexis-net-2004-sur-flickr /blog/2009/08/realisation-site-web-inexis-solution-web-2004/ 301
+/blog/2009/11/realisation-du-site-et-de-limage-«branding»-de-beebox-2008 /blog/2009/11/realisation-du-site-et-de-image-produit-de-beebox/ 301
+/blog/2009/11/realisation-du-site-et-de-limage-%c2%abbranding%c2%bb-de-beebox-2008 /blog/2009/11/realisation-du-site-et-de-image-produit-de-beebox/ 301
+/blog/2010/01/le-defi-«project52»-un-billet-par-semaine-minimum /blog/2010/01/le-defi-project52-un-billet-par-semaine/ 301
+/blog/2010/01/le-defi-%c2%abproject52%c2%bb-un-billet-par-semaine-minimum /blog/2010/01/le-defi-project52-un-billet-par-semaine/ 301
+/blog/2010/01/le-manifeste-open-cloud-pour-standardiser-linformatique-«dans-les-nuages» /blog/2010/01/le-manifeste-open-cloud-pour-standardiser-info-nuagique/ 301
+/blog/2010/01/le-manifeste-open-cloud-pour-standardiser-linformatique-%c2%abdans-les-nuages%c2%bb /blog/2010/01/le-manifeste-open-cloud-pour-standardiser-info-nuagique/ 301
+/blog/2010/02/realisation-dune-application-dechange-de-cadeau-avec-red-lagence-le-«club-echangiste»-2009 /blog/2010/02/realisation-dune-application-dechange-de-cadeau-avec-red-lagence/ 301
+/blog/2010/02/realisation-dune-application-dechange-de-cadeau-avec-red-lagence-le-%c2%abclub-echangiste%c2%bb-2009 /blog/2010/02/realisation-dune-application-dechange-de-cadeau-avec-red-lagence/ 301
+/blog/2013/07/i-am-joining-w3c-to-work-on-the-webplatform-project /blog/2013/08/i-am-joining-w3c-to-work-on-the-webplatform-project/ 301
+/blog/2013/07/i-am-joining-w3c-to-work-on-the-webplatform-project-2 /blog/2013/08/i-am-joining-w3c-to-work-on-the-webplatform-project/ 301
+/blog/2024/03/managing-email-aliases-with-protonmail-and-simplelogin-to-sort-automatically-into-inbox-folders-based-local-part /blog/2024/03/managing-email-aliases-with-protonmail-automatic-sorting/ 301
 #
 # PAGES THAT HAPPENED TO HAVE MANY URLS FOR THE SAME ARTICLE BECAUSE OF FLOCK BROWSER ----------
 #
-/blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical-2/ /blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical/ 301
-/blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical-3/ /blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical/ 301
-/blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical-4/ /blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical/ 301
-/blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical-5/ /blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical/ 301
-/blog/2007/08/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical-10/ /blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical/ 301
+/blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical-2 /blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical/ 301
+/blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical-3 /blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical/ 301
+/blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical-4 /blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical/ 301
+/blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical-5 /blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical/ 301
+/blog/2007/08/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical-10 /blog/2006/12/installer-vmware-sur-ubuntu-server-avec-le-repositoire-de-canonical/ 301
 #
 # TAXONOMY THAT CHANGED NAMES
 #


### PR DESCRIPTION
Gotta make sure we click on a link that's without that it handles it right, including with it too.

## Reason For This Issue

Vue/Nuxt doesn't hit CloudFlare in the same way when changing routes as when we're loading the first time.

The first time, the file at the path is finding the index file in the folder (i.e. a full HTTP cycle, with HTML, JS, paint, etc)

The second, as Nuxt/Vue does (because of its build process output) only loads JS code to update the current view and push to browser history.  Not a full HTTP cycle in the same way.

That's why redirects in _redirects aren't taken into account after the first load and navigating.