### PR TITLE
feat: Use renoirb-esm-modules custom elements and to display jsonresume

### DIFF
--- a/assets/styles/global.css
+++ b/assets/styles/global.css
@@ -35,3 +35,7 @@ a[href^="https://web.archive.org/"]:after
   unicode-bidi:bidi-override;
   direction: rtl;
 }
+
+:not(:defined) {
+  display: none;
+}

--- a/components/global/AppAlertBox.vue
+++ b/components/global/AppAlertBox.vue
@@ -1,4 +1,9 @@
 <template>
+  <!--
+    Historical Info:
+    This was before the file where I wrote first the rb-notice-box.
+    Now it's using https://github.com/renoirb/renoirb-esm-modules/
+  -->
   <rb-notice-box
     v-if="shouldBeVisible"
     :variant="alertType"

--- a/content/blog/2024/10/insert-custom-javascript-in-nuxt-config.md
+++ b/content/blog/2024/10/insert-custom-javascript-in-nuxt-config.md
@@ -63,11 +63,12 @@ script tag like the following:
 ```html
 <script type="module" defer>
   //
-  // Anything you might want. That's just something I've done.
+  // Anything you might want.
+  // Here, we're importing directly the entry point, but that can get messy quickly!
   //
-  import { registerCustomElement } from 'https://renoirb.com/esm-modules/element-utils.mjs'
-  import NoticeBoxElement from 'https://renoirb.com/esm-modules/notice-box-element.mjs'
-  registerCustomElement(window, 'rb-notice-box', NoticeBoxElement)
+  import { NoticeBoxElement } from "https://dist.renoirb.com/esm/own/notice-box-element/v0.2.0/browser.mjs";
+  // Which, in this case will load the element from https://dist.renoirb.com/esm/own/notice-box-element/v0.2.0/src/browser/element.mjs
+  customElements.define("rb-notice-box", NoticeBoxElement);
 </script>
 ```
 
@@ -164,9 +165,8 @@ import { NuxtConfig } from '@nuxt/types'
 // ...
 
 const THE_SCRIPT_CONTENTS_STATIC_STRING = `
-import { registerCustomElement } from 'https://renoirb.com/esm-modules/element-utils.mjs'
-import NoticeBoxElement from 'https://renoirb.com/esm-modules/notice-box-element.mjs'
-registerCustomElement(window, 'rb-notice-box', NoticeBoxElement)
+import { NoticeBoxElement } from "https://dist.renoirb.com/esm/own/notice-box-element/v0.2.0/browser.mjs";
+customElements.define("rb-notice-box", NoticeBoxElement);
 `
 
 const main: NuxtConfig = {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,35 +1,36 @@
 <template>
-  <div :class="{ 'layouts--default': true, 'is-side-bar-open': isOpen }">
-    <inline-svg
-      :src="require('~/assets/images/2235845.svg')"
-      width="1200"
-      height="1200"
-      style="
-        fill: var(--color-sandwich-left-splat-bg) !important;
-        position: fixed;
-        left: -580px;
-        z-index: -2;
-        top: 1%;
-        margin-top: -300px;
-      "
-      class="lg:visible z-10 invisible"
-    ></inline-svg>
-    <app-header class="top z-50" @side-bar-open="onOpen($event)" />
-    <div v-show="isOpen" class="fixed inset-0 z-40 transition-opacity">
-      <div class="absolute inset-0 bg-black opacity-75"></div>
+  <rb-app-layout>
+    <div slot="top-left">
+      <NuxtLink
+        to="/"
+        class="text-2xl font-semibold"
+        style="color: var(--color-sandwich-text); opacity: 1"
+        data-wip="From AppSideBar"
+      >
+        {{ appTitle }}
+      </NuxtLink>
     </div>
-    <main class="zone__sandwich__meat middle container z-40 mx-auto">
-      <div class="md:m-10 grid grid-cols-1 m-5" data-wip="layout/default.vue">
-        <nuxt />
-      </div>
+    <div slot="top-right" class="container flex items-center justify-between">
+      <NuxtLink
+        v-for="({ label, to }, index) of nav"
+        :key="`${label}--${index}`"
+        :to="to"
+        class="hover:opacity-100 opacity-80 hover:underline flex items-center p-3 px-4 py-2 mr-2 font-medium text-center rounded"
+      >
+        {{ label }}
+      </NuxtLink>
+    </div>
+    <main>
+      <nuxt />
     </main>
-    <app-footer v-bind="appIdentity" class="bottom" />
-  </div>
+    <app-footer slot="footer-left" v-bind="appIdentity" />
+  </rb-app-layout>
 </template>
 
 <script lang="ts">
   import Vue from 'vue'
   import {
+    appHeaderNav,
     fromNuxtContextToAppIdentity,
     fromPackageToAppIdentity,
     IAppIdentity,
@@ -38,7 +39,12 @@
     getColorModeClassName,
     /*                       */
   } from '~/lib'
+  import type {
+    IAppHeaderNavItems,
+    /*                       */
+  } from '~/lib'
   export interface Data {
+    nav: IAppHeaderNavItems[]
     appIdentity: IAppIdentity
     colorModeClassName: string
     pageTitle: string
@@ -62,7 +68,10 @@
         ...appIdentityFallback,
         ...appIdentityPicks,
       }
+      const appTitle = appIdentity?.name || 'Renoir B. - Blog'
       return {
+        appTitle,
+        nav: appHeaderNav,
         appIdentity,
         colorModeClassName,
         isOpen: false,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -35,7 +35,10 @@ const main: NuxtConfig = {
   target: 'static',
   vue: {
     config: {
-      ignoredElements: [/^rb-/],
+      ignoredElements: [
+        /^rb-/ /* rel=#WIP-Mingle-CustomElements-From-ESM-Modules */,
+        /^value-date/ /* rel=#WIP-Mingle-CustomElements-From-ESM-Modules */,
+      ],
     },
   },
   /*
@@ -86,6 +89,10 @@ const main: NuxtConfig = {
       // <script src="https://myawesome-lib.js"></script>
       // { src: 'https://awesome-lib.js' },
       // https://vue-meta.nuxtjs.org/api/#script
+      {
+        src: './static-import-map.js',
+        vmid: 'load-from-static-slash-import-map',
+      },
       {
         src: './main.mjs',
         type: 'module',

--- a/static/assets/js/register-elements.mjs
+++ b/static/assets/js/register-elements.mjs
@@ -9,38 +9,62 @@
  * rel=#WIP-Mingle-CustomElements-From-ESM-Modules
  */
 
-import { registerCustomElement } from 'https://renoirb.com/esm-modules/element-utils.mjs'
+import {
+  /*                    */
+  NoticeBoxElement,
+} from "@renoirb/notice-box-element";
+import ValueDateElement, {
+  ValueDateRangeElement,
+} from "@renoirb/value-date-element";
+import {
+  /*                    */
+  InlineNoteElement,
+} from "@renoirb/inline-note-element";
 
 const ELEMENTS = [
-  ['rb-notice-box', import('https://renoirb.com/esm-modules/notice-box-element.mjs')],
-]
+  {
+    name: "rb-notice-box",
+    element: NoticeBoxElement,
+  },
+  {
+    name: "value-date-range",
+    element: ValueDateRangeElement,
+  },
+  {
+    name: "value-date",
+    element: ValueDateElement,
+  },
+  {
+    name: "rb-inline-note",
+    element: InlineNoteElement,
+  },
+];
 
-const main = async ({ SITE_ROOT_BASE_URL = './' }) => {
-  await Promise.resolve()
+const main = async () => {
+  await import(
+    "https://dist.renoirb.com/esm/own/value-date-element/v0.5.0/example-context-api.mjs?setup&delay"
+  );
+  await Promise.resolve();
 
-  ELEMENTS.push(
-    ['rb-content-edit', import(`${SITE_ROOT_BASE_URL}esm-modules/element-content-edit/0.1.0/index.mjs`)],
-  )
+  const loaded = [];
+  const errored = [];
 
-  const loaded = []
-  const errored = []
-
-  ELEMENTS.forEach(async ([elementName, importator]) => {
-    const closature = await importator
-    try {
-      registerCustomElement(window, elementName, closature.default)
-      loaded.push(elementName)
-    } catch {
-      const message = `Element ${elementName} is already loaded`
-      console.warn(message)
-      errored.push(elementName)
+  for (const { name, element } of ELEMENTS) {
+    if (name && element) {
+      try {
+        customElements.define(name, element);
+        loaded.push(name);
+      } catch (e) {
+        console.error(`Failed to register ${name}`, e); // eslint-disable-line no-console
+        errored.push(name);
+      }
     }
-  })
+  }
 
   return {
     loaded,
     errored,
-  }
-}
+  };
+};
 
-export default main
+export default main;

--- a/static/assets/js/register-elements.mjs
+++ b/static/assets/js/register-elements.mjs
@@ -11,6 +11,10 @@
 
 import {
   /*                    */
+  AppLayoutAlphaElement,
+} from "@renoirb/app-layout-element";
+import {
+  /*                    */
   NoticeBoxElement,
 } from "@renoirb/notice-box-element";
 import ValueDateElement, {
@@ -22,6 +26,10 @@ import {
 } from "@renoirb/inline-note-element";
 
 const ELEMENTS = [
+  {
+    name: "rb-app-layout",
+    element: AppLayoutAlphaElement,
+  },
   {
     name: "rb-notice-box",
     element: NoticeBoxElement,

--- a/static/main.mjs
+++ b/static/main.mjs
@@ -1,24 +1,36 @@
-
 /**
  * This should work for file:/// URLs
  * (assuming it's supported, Safari does, not Chromium thus far 2023-02-03)
  */
-const SITE_ROOT_BASE_URL = await import.meta.url?.replace('main.mjs', '')
+const SITE_ROOT_BASE_URL = await import.meta.url?.replace("main.mjs", "");
+
+// Equivalent of an application environment variable
+const currentEnv = Object.freeze({
+  SITE_ROOT_BASE_URL,
+});
+Object.defineProperty(window, "currentEnv", {
+  value: currentEnv,
+  writable: false,
+});
 
 const main = async () => {
   await Promise.resolve()
+
   try {
     // Things should display regardless of whether all elements are registered. Just less pretty.
-    const { default: registerElements } = await import('./assets/js/register-elements.mjs')
-    await registerElements({ SITE_ROOT_BASE_URL })
+    const { default: registerElements } = await import(
+      "./assets/js/register-elements.mjs"
+    );
+    await registerElements();
   } catch (_e) {
-    const message = `We could not load our elements from ./assets/js/register-elements.mjs, let's fail gracefully. Error message: ` + _e
-    console.warn(message)
+    const message =
+      `We could not load our elements from ./assets/js/register-elements.mjs, let's fail gracefully. Error message: ` +
+      _e;
+    console.warn(message); // eslint-disable-line no-console
   }
-}
-
+};
 
 // ----------------------------------------------------------------------------
-main().catch(e => {
-  console.error(`Something went wrong`, e)
-})
+main().catch((e) => {
+  console.error(`Something went wrong`, e);
+});

--- a/static/static-import-map.js
+++ b/static/static-import-map.js
@@ -1,0 +1,35 @@
+/**
+ * See also https://renoirb.com/import-map.js
+ *
+ * rel=#WIP-Mingle-CustomElements-From-ESM-Modules
+ */
+(function () {
+  const imports = {
+    "@renoirb/notice-box-element":
+      "https://dist.renoirb.com/esm/own/notice-box-element/v0.2.0/browser.mjs",
+    "@renoirb/value-date-element":
+      "https://dist.renoirb.com/esm/own/value-date-element/v0.5.0/browser.mjs",
+    "@renoirb/inline-note-element":
+      "https://dist.renoirb.com/esm/own/inline-note-element/v0.2.0/browser.mjs",
+    "@renoirb/context-api":
+      "https://dist.renoirb.com/esm/own/context-api/v1.0.0/browser.mjs",
+    "@renoirb/http-utils":
+      "https://dist.renoirb.com/esm/own/http-utils/v0.1.0/browser.mjs",
+    "@renoirb/element-utils":
+      "https://dist.renoirb.com/esm/own/element-utils/v0.4.0/browser.mjs",
+  };
+  const importMap = document.createElement("script");
+  importMap.type = "importmap";
+  importMap.textContent = JSON.stringify({ imports });
+  importMap.setAttribute("id", "importMap");
+  importMap.setAttribute("data-created-via", "static-import-map.js");
+  Reflect.set(importMap, "imports", imports);
+  if (document?.currentScript) {
+    document.currentScript.parentNode.insertBefore(
+      importMap,
+      document.currentScript,
+    );
+  } else {
+    document.head.appendChild(importMap);
+  }
+})();

--- a/static/static-import-map.js
+++ b/static/static-import-map.js
@@ -5,6 +5,8 @@
  */
 (function () {
   const imports = {
+    "@renoirb/app-layout-element":
+      "http://localhost:8000/packages/app-layout-element/browser.mjs",
     "@renoirb/notice-box-element":
       "https://dist.renoirb.com/esm/own/notice-box-element/v0.2.0/browser.mjs",
     "@renoirb/value-date-element":
@@ -13,10 +15,16 @@
       "https://dist.renoirb.com/esm/own/inline-note-element/v0.2.0/browser.mjs",
     "@renoirb/context-api":
       "https://dist.renoirb.com/esm/own/context-api/v1.0.0/browser.mjs",
+    "@renoirb/jsonresume-utils":
+      "https://dist.renoirb.com/esm/own/jsonresume-utils/v0.1.0/core.mjs",
     "@renoirb/http-utils":
       "https://dist.renoirb.com/esm/own/http-utils/v0.1.0/browser.mjs",
+    "@renoirb/jsonresume-element":
+      "https://dist.renoirb.com/esm/own/jsonresume-element/v0.1.0/browser.mjs",
     "@renoirb/element-utils":
       "https://dist.renoirb.com/esm/own/element-utils/v0.4.0/browser.mjs",
+    "@renoirb/markdown-content-element":
+      "https://dist.renoirb.com/esm/own/markdown-content-element/v0.2.0/browser.mjs",
   };
   const importMap = document.createElement("script");
   importMap.type = "importmap";


### PR DESCRIPTION
Fully leverage https://github.com/renoirb/renoirb-esm-modules/ packages using importMap from a Vue/Nuxt application.

WIP, currently working:
- [@renoirb/notice-box-element](https://github.com/renoirb/renoirb-esm-modules/blob/main/packages/notice-box-element/)
- [@renoirb/app-layout-element](https://github.com/renoirb/renoirb-esm-modules/blob/main/packages/app-layout-element/)
- [@renoirb/inline-note-element](https://github.com/renoirb/renoirb-esm-modules/blob/main/packages/inline-note-element/)
- [**value-date**, and **value-date-range**](https://github.com/renoirb/renoirb-esm-modules/blob/main/packages/value-date-element/)
- [the WCCG *Context API* protocol](https://github.com/renoirb/renoirb-esm-modules/blob/main/packages/context-api/README.md)

It'll be the same elements as in use in my cover-letters I am writing.